### PR TITLE
Rename runtime pallets

### DIFF
--- a/node/dev/src/chain_spec.rs
+++ b/node/dev/src/chain_spec.rs
@@ -243,13 +243,13 @@ fn development_genesis(
 		bfc_utility: Default::default(),
 		bfc_offences: Default::default(),
 		democracy: Default::default(),
-		council_collective: Default::default(),
-		tech_committee_collective: Default::default(),
+		council: Default::default(),
+		technical_committee: Default::default(),
 		council_membership: devnet::CouncilMembershipConfig {
 			phantom: Default::default(),
 			members: initial_council_members.clone(),
 		},
-		tech_committee_membership: devnet::TechCommitteeMembershipConfig {
+		technical_membership: devnet::TechnicalMembershipConfig {
 			phantom: Default::default(),
 			members: initial_tech_committee_members.clone(),
 		},

--- a/node/testnet/src/chain_spec.rs
+++ b/node/testnet/src/chain_spec.rs
@@ -218,13 +218,13 @@ fn testnet_genesis(
 		bfc_utility: Default::default(),
 		bfc_offences: Default::default(),
 		democracy: Default::default(),
-		council_collective: Default::default(),
-		tech_committee_collective: Default::default(),
+		council: Default::default(),
+		technical_committee: Default::default(),
 		council_membership: testnet::CouncilMembershipConfig {
 			phantom: Default::default(),
 			members: initial_council_members.clone(),
 		},
-		tech_committee_membership: testnet::TechCommitteeMembershipConfig {
+		technical_membership: testnet::TechnicalMembershipConfig {
 			phantom: Default::default(),
 			members: initial_tech_committee_members.clone(),
 		},

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -133,7 +133,7 @@ pub mod opaque {
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The identifier for the different Substrate runtimes.
-	spec_name: create_runtime_str!("root"),
+	spec_name: create_runtime_str!("thebifrost-dev"),
 	// The name of the implementation of the spec.
 	impl_name: create_runtime_str!("bifrost-dev"),
 	// The version of the authorship interface.

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -133,13 +133,13 @@ pub mod opaque {
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The identifier for the different Substrate runtimes.
-	spec_name: create_runtime_str!("moonbeam"),
+	spec_name: create_runtime_str!("root"),
 	// The name of the implementation of the spec.
 	impl_name: create_runtime_str!("bifrost-dev"),
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 250,
+	spec_version: 255,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.
@@ -443,8 +443,8 @@ impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {
 	type AddOrigin = MoreThanHalfCouncil;
 	type Event = Event;
 	type MaxMembers = CouncilMaxMembers;
-	type MembershipChanged = CouncilCollective;
-	type MembershipInitialized = CouncilCollective;
+	type MembershipChanged = Council;
+	type MembershipInitialized = Council;
 	type PrimeOrigin = MoreThanHalfCouncil;
 	type RemoveOrigin = MoreThanHalfCouncil;
 	type ResetOrigin = MoreThanHalfCouncil;
@@ -457,8 +457,8 @@ impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type AddOrigin = MoreThanHalfCouncil;
 	type Event = Event;
 	type MaxMembers = TechCommitteeMaxMembers;
-	type MembershipChanged = TechCommitteeCollective;
-	type MembershipInitialized = TechCommitteeCollective;
+	type MembershipChanged = TechnicalCommittee;
+	type MembershipInitialized = TechnicalCommittee;
 	type PrimeOrigin = MoreThanHalfCouncil;
 	type RemoveOrigin = MoreThanHalfCouncil;
 	type ResetOrigin = MoreThanHalfCouncil;
@@ -949,10 +949,10 @@ construct_runtime!(
 		// Governance
 		Scheduler: pallet_scheduler::{Pallet, Storage, Event<T>, Call} = 50,
 		Democracy: pallet_democracy::{Pallet, Storage, Config<T>, Event<T>, Call} = 51,
-		CouncilCollective: pallet_collective::<Instance1>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 52,
-		TechCommitteeCollective: pallet_collective::<Instance2>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 53,
+		Council: pallet_collective::<Instance1>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 52,
+		TechnicalCommittee: pallet_collective::<Instance2>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 53,
 		CouncilMembership: pallet_membership::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>} = 54,
-		TechCommitteeMembership: pallet_membership::<Instance2>::{Pallet, Call, Storage, Event<T>, Config<T>} = 55,
+		TechnicalMembership: pallet_membership::<Instance2>::{Pallet, Call, Storage, Event<T>, Config<T>} = 55,
 		Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>} = 56,
 
 		// Temporary

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -491,8 +491,8 @@ impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {
 	type AddOrigin = MoreThanHalfCouncil;
 	type Event = Event;
 	type MaxMembers = CouncilMaxMembers;
-	type MembershipChanged = CouncilCollective;
-	type MembershipInitialized = CouncilCollective;
+	type MembershipChanged = Council;
+	type MembershipInitialized = Council;
 	type PrimeOrigin = MoreThanHalfCouncil;
 	type RemoveOrigin = MoreThanHalfCouncil;
 	type ResetOrigin = MoreThanHalfCouncil;
@@ -505,8 +505,8 @@ impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type AddOrigin = MoreThanHalfCouncil;
 	type Event = Event;
 	type MaxMembers = TechCommitteeMaxMembers;
-	type MembershipChanged = TechCommitteeCollective;
-	type MembershipInitialized = TechCommitteeCollective;
+	type MembershipChanged = TechnicalCommittee;
+	type MembershipInitialized = TechnicalCommittee;
 	type PrimeOrigin = MoreThanHalfCouncil;
 	type RemoveOrigin = MoreThanHalfCouncil;
 	type ResetOrigin = MoreThanHalfCouncil;
@@ -954,10 +954,10 @@ construct_runtime!(
 		// Governance
 		Scheduler: pallet_scheduler::{Pallet, Storage, Event<T>, Call} = 50,
 		Democracy: pallet_democracy::{Pallet, Storage, Config<T>, Event<T>, Call} = 51,
-		CouncilCollective: pallet_collective::<Instance1>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 52,
-		TechCommitteeCollective: pallet_collective::<Instance2>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 53,
+		Council: pallet_collective::<Instance1>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 52,
+		TechnicalCommittee: pallet_collective::<Instance2>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 53,
 		CouncilMembership: pallet_membership::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>} = 54,
-		TechCommitteeMembership: pallet_membership::<Instance2>::{Pallet, Call, Storage, Event<T>, Config<T>} = 55,
+		TechnicalMembership: pallet_membership::<Instance2>::{Pallet, Call, Storage, Event<T>, Config<T>} = 55,
 		Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>} = 56,
 
 		// Temporary

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -134,7 +134,7 @@ pub mod opaque {
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The identifier for the different Substrate runtimes.
-	spec_name: create_runtime_str!("moonbeam"),
+	spec_name: create_runtime_str!("thebifrost-testnet"),
 	// The name of the implementation of the spec.
 	impl_name: create_runtime_str!("bifrost-testnet"),
 	// The version of the authorship interface.


### PR DESCRIPTION
## Description

- Rename runtime pallets to polkadot runtime style.
- Rename runtime `spec_name`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Something else (simple changes that are not related to existing functionality or others)
