### PR TITLE
Release BIFROST v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "bifrost-node"
-version = "1.2.0-pre"
+version = "1.2.0"
 dependencies = [
  "bifrost-common-node",
  "bifrost-dev-node",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage: where we create binary
-FROM rust:1.62 AS builder
+FROM rust:1.66 AS builder
 
 RUN apt update && apt install -y make clang pkg-config libssl-dev
 RUN rustup default stable && \
@@ -17,7 +17,7 @@ FROM ubuntu:22.04
 
 RUN apt update && apt install -y curl unzip
 
-RUN curl -fsSL https://fnm.vercel.app/install | bash
+RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "/root/.fnm"
 RUN /root/.fnm/fnm install 16.18.1
 
 COPY --from=builder /bifrost/target/release/bifrost-node /usr/local/bin

--- a/node/core/Cargo.toml
+++ b/node/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bifrost-node"
-version = "1.2.0-pre"
+version = "1.2.0"
 description = "The node specification for BIFROST Node"
 authors = ["bifrost-platform"]
 homepage = "https://thebifrost.io"

--- a/pallets/bfc-offences/src/pallet/mod.rs
+++ b/pallets/bfc-offences/src/pallet/mod.rs
@@ -122,7 +122,7 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {
-			StorageVersion::<T>::put(Releases::V1_0_0);
+			StorageVersion::<T>::put(Releases::V2_0_0);
 			OffenceExpirationInSessions::<T>::put(T::DefaultOffenceExpirationInSessions::get());
 			FullMaximumOffenceCount::<T>::put(T::DefaultFullMaximumOffenceCount::get());
 			BasicMaximumOffenceCount::<T>::put(T::DefaultBasicMaximumOffenceCount::get());
@@ -133,6 +133,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::set_offence_expiration()
 		)]
@@ -150,6 +151,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::set_max_offence_count()
 		)]
@@ -198,6 +200,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::set_offence_activation()
 		)]
@@ -213,6 +216,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(3)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::set_slash_activation()
 		)]

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -1545,26 +1545,24 @@ impl<
 			.nominations
 			.0
 			.clone()
-			.iter()
-			.map(|n| {
-				if &n.owner == old {
-					Bond { owner: new.clone(), amount: n.amount }
-				} else {
-					n.clone()
+			.into_iter()
+			.map(|mut n| {
+				if n.owner == *old {
+					n.owner = new.clone();
 				}
+				n
 			})
 			.collect();
 		self.initial_nominations.0 = self
 			.initial_nominations
 			.0
 			.clone()
-			.iter()
-			.map(|n| {
-				if &n.owner == old {
-					Bond { owner: new.clone(), amount: n.amount }
-				} else {
-					n.clone()
+			.into_iter()
+			.map(|mut n| {
+				if n.owner == *old {
+					n.owner = new.clone();
 				}
+				n
 			})
 			.collect();
 	}

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -2,31 +2,31 @@ use super::*;
 
 pub mod v3 {
 	use super::*;
-	use frame_support::traits::Get;
+	// use frame_support::traits::Get;
 
 	pub fn migrate<T: Config>() -> Weight {
-		let mut candidate_pool = CandidatePool::<T>::get();
-		for mut candidate in CandidateInfo::<T>::iter() {
-			let mut is_contained = false;
-			for c in candidate_pool.iter() {
-				if c.owner == candidate.0 {
-					is_contained = true;
-					break
-				}
-			}
-			if !is_contained {
-				candidate.1.reset_blocks_produced();
-				candidate_pool
-					.push(Bond { owner: candidate.0.clone(), amount: candidate.1.voting_power });
-			}
-			candidate.1.reset_productivity();
-			candidate.1.status = ValidatorStatus::Active;
-			CandidateInfo::<T>::insert(&candidate.0, candidate.1.clone());
-		}
-		Pallet::<T>::sort_candidates_by_voting_power();
-		CandidatePool::<T>::put(candidate_pool);
-		// StorageVersion::<T>::put(Releases::V3_0_0);
-		crate::log!(info, "bfc-staking migration passes Releases::V3_0_0 migrate checks ✅");
+		// let mut candidate_pool = CandidatePool::<T>::get();
+		// for mut candidate in CandidateInfo::<T>::iter() {
+		// 	let mut is_contained = false;
+		// 	for c in candidate_pool.iter() {
+		// 		if c.owner == candidate.0 {
+		// 			is_contained = true;
+		// 			break
+		// 		}
+		// 	}
+		// 	if !is_contained {
+		// 		candidate.1.reset_blocks_produced();
+		// 		candidate_pool
+		// 			.push(Bond { owner: candidate.0.clone(), amount: candidate.1.voting_power });
+		// 	}
+		// 	candidate.1.reset_productivity();
+		// 	candidate.1.status = ValidatorStatus::Active;
+		// 	CandidateInfo::<T>::insert(&candidate.0, candidate.1.clone());
+		// }
+		// Pallet::<T>::sort_candidates_by_voting_power();
+		// CandidatePool::<T>::put(candidate_pool);
+		// // StorageVersion::<T>::put(Releases::V3_0_0);
+		// crate::log!(info, "bfc-staking migration passes Releases::V3_0_0 migrate checks ✅");
 		T::BlockWeights::get().max_block
 	}
 }

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -397,6 +397,7 @@ impl<T: Config> Pallet<T> {
 		});
 	}
 
+	/// Apply the delayed candidate rate set requests.
 	pub fn handle_delayed_commission_sets(now: RoundIndex) {
 		let delayed_round = now - 1;
 		let commission_sets = <DelayedCommissionSets<T>>::take(delayed_round);

--- a/pallets/bfc-staking/src/pallet/mod.rs
+++ b/pallets/bfc-staking/src/pallet/mod.rs
@@ -789,53 +789,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		#[pallet::weight(
-			<T as Config>::WeightInfo::hotfix_remove_nomination_requests(nominators.len() as u32)
-		)]
-		/// Hotfix patch to remove all nomination requests not removed during a candidate exit
-		pub fn hotfix_remove_nomination_requests(
-			origin: OriginFor<T>,
-			nominators: Vec<T::AccountId>,
-		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
-			for nominator in nominators {
-				if let Some(mut state) = <NominatorState<T>>::get(&nominator) {
-					// go through all requests and remove ones without corresponding nomination
-					for (candidate, request) in state.requests.requests.clone().into_iter() {
-						if !state.nominations.0.iter().any(|x| x.owner == candidate) {
-							state.requests.requests.remove(&candidate);
-							state.requests.less_total =
-								state.requests.less_total.saturating_sub(request.amount);
-							if matches!(request.action, NominationChange::Revoke) {
-								state.requests.revocations_count -= 1u32;
-							}
-						}
-					}
-					<NominatorState<T>>::insert(&nominator, state);
-				} // else nominator is not a nominator so no update needed
-			}
-			Ok(().into())
-		}
-
-		#[pallet::weight(
-			<T as Config>::WeightInfo::hotfix_update_candidate_pool_value(candidates.len() as u32)
-		)]
-		/// Hotfix patch to correct and update CandidatePool value for candidates that have
-		/// called candidate_bond_more when it did not update the CandidatePool value
-		pub fn hotfix_update_candidate_pool_value(
-			origin: OriginFor<T>,
-			candidates: Vec<T::AccountId>,
-		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
-			for candidate in candidates {
-				if let Some(state) = <CandidateInfo<T>>::get(&candidate) {
-					Self::update_active(&candidate, state.voting_power);
-					Self::sort_candidates_by_voting_power();
-				} // else candidate is not a candidate so no update needed
-			}
-			Ok(().into())
-		}
-
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_staking_expectations())]
 		/// Set the expectations for total staked. These expectations determine the issuance for
 		/// the round according to logic in `fn compute_issuance`
@@ -857,6 +811,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_inflation())]
 		/// Set the annual inflation rate to derive per-round inflation
 		pub fn set_inflation(
@@ -881,6 +836,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_max_total_selected())]
 		/// Set the maximum number of full validator candidates selected per round
 		pub fn set_max_full_selected(origin: OriginFor<T>, new: u32) -> DispatchResultWithPostInfo {
@@ -898,6 +854,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_max_total_selected())]
 		/// Set the maximum number of basic validator candidates selected per round
 		pub fn set_max_basic_selected(
@@ -918,6 +875,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_min_total_selected())]
 		/// Set the minimum number of validator candidates selected per round
 		pub fn set_min_total_selected(
@@ -937,6 +895,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_default_validator_commission())]
 		/// Set the default commission rate for all validators of the given tier
 		pub fn set_default_validator_commission(
@@ -991,6 +950,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(6)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_max_validator_commission())]
 		/// Set the maximum commission rate for all validators of the given tier
 		pub fn set_max_validator_commission(
@@ -1037,6 +997,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(7)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_validator_commission())]
 		/// Set the commission rate of the given validator
 		/// - origin should be the controller account
@@ -1062,6 +1023,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(8)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_validator_commission_set())]
 		/// Cancel the request for (re-)setting the commission rate.
 		/// - origin should be the controller account.
@@ -1074,6 +1036,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(9)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_validator_tier())]
 		/// Modify validator candidate tier. The actual state reflection will apply at the next
 		/// round
@@ -1117,6 +1080,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(10)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_blocks_per_round())]
 		/// Set blocks per round
 		/// - the `new` round length will be updated immediately in the next block
@@ -1158,6 +1122,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(11)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_storage_cache_lifetime())]
 		/// Set the `StorageCacheLifetime` round length
 		pub fn set_storage_cache_lifetime(
@@ -1173,6 +1138,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(12)]
 		#[pallet::weight(<T as Config>::WeightInfo::join_candidates(*candidate_count))]
 		/// Join the set of validator candidates
 		/// - origin should be the stash account
@@ -1234,6 +1200,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(13)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_leave_candidates(*candidate_count))]
 		/// Request to leave the set of candidates. If successful, the account is immediately
 		/// removed from the candidate pool to prevent selection as a validator.
@@ -1263,6 +1230,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(14)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::execute_leave_candidates(*candidate_nomination_count)
 		)]
@@ -1340,6 +1308,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(15)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_leave_candidates(*candidate_count))]
 		/// Cancel open request to leave candidates
 		/// - only callable by validator account
@@ -1368,6 +1337,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(16)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_controller())]
 		/// (Re-)set the bonded controller account. The origin must be the bonded stash account. The
 		/// actual change will apply on the next round update.
@@ -1389,6 +1359,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(17)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_controller_set())]
 		/// Cancel the request for (re-)setting the bonded controller account.
 		/// - origin should be the controller account.
@@ -1404,6 +1375,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(18)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_candidate_reward_dst())]
 		/// Set the validator candidate reward destination
 		/// - origin should be the controller account
@@ -1425,6 +1397,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(19)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_nominator_reward_dst())]
 		/// Set the nominator reward destination
 		pub fn set_nominator_reward_dst(
@@ -1445,6 +1418,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(20)]
 		#[pallet::weight(<T as Config>::WeightInfo::go_offline())]
 		/// Temporarily leave the set of validator candidates without unbonding
 		/// - removed from candidate pool
@@ -1496,6 +1470,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(21)]
 		#[pallet::weight(<T as Config>::WeightInfo::go_online())]
 		/// Rejoin the set of validator candidates if previously been kicked out or went offline
 		/// - state changed to `Active`
@@ -1518,6 +1493,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(22)]
 		#[pallet::weight(<T as Config>::WeightInfo::candidate_bond_more())]
 		/// Increase validator candidate self bond by `more`
 		/// - origin should be the stash account
@@ -1537,6 +1513,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(23)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_candidate_bond_less())]
 		/// Request by validator candidate to decrease self bond by `less`
 		/// - origin should be the controller account
@@ -1557,6 +1534,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(24)]
 		#[pallet::weight(<T as Config>::WeightInfo::execute_candidate_bond_less())]
 		/// Execute pending request to adjust the validator candidate self bond
 		/// - origin should be the stash account
@@ -1570,6 +1548,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(25)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_candidate_bond_less())]
 		/// Cancel pending request to adjust the validator candidate self bond
 		/// - origin should be the controller account
@@ -1581,6 +1560,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(26)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::nominate(
 				*candidate_nomination_count,
@@ -1653,6 +1633,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(27)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_leave_nominators())]
 		/// Request to leave the set of nominators. If successful, the caller is scheduled
 		/// to be allowed to exit. Success forbids future nominator actions until the request is
@@ -1672,6 +1653,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(28)]
 		#[pallet::weight(<T as Config>::WeightInfo::execute_leave_nominators(*nomination_count))]
 		/// Execute the right to exit the set of nominators and revoke all ongoing nominations.
 		pub fn execute_leave_nominators(
@@ -1699,6 +1681,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(29)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_leave_nominators())]
 		/// Cancel a pending request to exit the set of nominators. Success clears the pending exit
 		/// request (thereby resetting the delay upon another `leave_nominators` call).
@@ -1715,6 +1698,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(30)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_revoke_nomination())]
 		/// Request to revoke an existing nomination. If successful, the nomination is scheduled
 		/// to be allowed to be revoked via the `execute_nomination_request` extrinsic.
@@ -1736,6 +1720,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(31)]
 		#[pallet::weight(<T as Config>::WeightInfo::nominator_bond_more())]
 		/// Bond more for nominators wrt a specific validator candidate.
 		pub fn nominator_bond_more(
@@ -1750,6 +1735,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(32)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_nominator_bond_less())]
 		/// Request bond less for nominators wrt a specific validator candidate.
 		pub fn schedule_nominator_bond_less(
@@ -1771,6 +1757,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(33)]
 		#[pallet::weight(<T as Config>::WeightInfo::execute_nominator_bond_less())]
 		/// Execute pending request to change an existing nomination
 		pub fn execute_nomination_request(
@@ -1784,6 +1771,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(34)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_nominator_bond_less())]
 		/// Cancel request to change an existing nomination.
 		pub fn cancel_nomination_request(

--- a/pallets/bfc-staking/src/pallet/mod.rs
+++ b/pallets/bfc-staking/src/pallet/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use bp_staking::{
 	traits::{OffenceHandler, RelayManager},
-	MAX_VALIDATORS,
+	MAX_AUTHORITIES,
 };
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
@@ -502,19 +502,19 @@ pub mod pallet {
 	#[pallet::getter(fn selected_candidates)]
 	/// The active validator set (full and basic) selected for the current round
 	pub type SelectedCandidates<T: Config> =
-		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
+		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn selected_full_candidates)]
 	/// The active full validator set selected for the current round
 	pub type SelectedFullCandidates<T: Config> =
-		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
+		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn selected_basic_candidates)]
 	/// The active basic validator set selected for the current round
 	pub type SelectedBasicCandidates<T: Config> =
-		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
+		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn cached_selected_candidates)]
@@ -542,7 +542,7 @@ pub mod pallet {
 	/// The pool of validator candidates, each with their total voting power
 	pub(crate) type CandidatePool<T: Config> = StorageValue<
 		_,
-		BoundedVec<Bond<T::AccountId, BalanceOf<T>>, ConstU32<MAX_VALIDATORS>>,
+		BoundedVec<Bond<T::AccountId, BalanceOf<T>>, ConstU32<MAX_AUTHORITIES>>,
 		ValueQuery,
 	>;
 
@@ -578,7 +578,7 @@ pub mod pallet {
 		_,
 		Twox64Concat,
 		RoundIndex,
-		BoundedVec<DelayedControllerSet<T::AccountId>, ConstU32<MAX_VALIDATORS>>,
+		BoundedVec<DelayedControllerSet<T::AccountId>, ConstU32<MAX_AUTHORITIES>>,
 		ValueQuery,
 	>;
 
@@ -588,7 +588,7 @@ pub mod pallet {
 		_,
 		Twox64Concat,
 		RoundIndex,
-		BoundedVec<DelayedCommissionSet<T::AccountId>, ConstU32<MAX_VALIDATORS>>,
+		BoundedVec<DelayedCommissionSet<T::AccountId>, ConstU32<MAX_AUTHORITIES>>,
 		ValueQuery,
 	>;
 

--- a/pallets/bfc-staking/src/pallet/mod.rs
+++ b/pallets/bfc-staking/src/pallet/mod.rs
@@ -135,57 +135,109 @@ pub mod pallet {
 
 	#[pallet::error]
 	pub enum Error<T> {
+		/// A nominator does not exist with the target account.
 		NominatorDNE,
+		/// A candidate does not exist with the target controller account.
 		CandidateDNE,
+		/// A candidate does not exist with the target stash account.
 		StashDNE,
+		/// A nomination does not exist with the target nominator and candidate account.
 		NominationDNE,
+		/// A commission set request does not exist with the target controller account.
 		CommissionSetDNE,
+		/// A controller set request does not exist with the target controller account.
 		ControllerSetDNE,
+		/// The given account is already used as a nominator.
 		NominatorExists,
+		/// The given account is already used as a candidate.
 		CandidateExists,
+		/// The given amount does not reach the minimum self-bond requirement.
 		CandidateBondBelowMin,
+		/// The given account has insufficient balance to pay.
 		InsufficientBalance,
+		/// The given amount does not reach the minimum nomination requirement.
 		NominatorBondBelowMin,
+		/// The given amount does not reach the minimum nomination requirement.
 		NominationBelowMin,
+		/// The given candidate is already offline.
 		AlreadyOffline,
+		/// The given candidate is already online.
 		AlreadyActive,
+		/// The given stash account is already bonded.
 		AlreadyBonded,
+		/// The given controller account is already paired.
 		AlreadyPaired,
+		/// The given nominator is already leaving.
 		NominatorAlreadyLeaving,
+		/// The given nominator is not leaving.
 		NominatorNotLeaving,
+		/// The given nominator cannot execute to leave yet.
 		NominatorCannotLeaveYet,
+		/// The given nominator cannot nominate due to its leaving state.
 		CannotNominateIfLeaving,
+		/// The given candidate is already leaving.
 		CandidateAlreadyLeaving,
+		/// The given candidate is not leaving.
 		CandidateNotLeaving,
+		/// The given candidate cannot execute to leave yet.
 		CandidateCannotLeaveYet,
+		/// The given candidate cannot go online due to its leaving state.
 		CannotGoOnlineIfLeaving,
+		/// The given candidate cannot leave due to its offline state.
 		CannotLeaveIfOffline,
+		/// The given nominator exceeds the maximum limit of nominations.
 		ExceedMaxNominationsPerNominator,
+		/// The given nominator already nominated the candidate.
 		AlreadyNominatedCandidate,
+		/// The given candidate has already requested a controller set.
 		AlreadyControllerSetRequested,
+		/// The given candidate has already requested a commission set.
 		AlreadyCommissionSetRequested,
+		/// The requested inflation options are invalid.
 		InvalidSchedule,
+		/// The requested tier type are invalid.
 		InvalidTierType,
+		/// The requested value are below the minimum value.
 		CannotSetBelowMin,
+		/// The requested value are below one.
 		CannotSetBelowOne,
+		/// The requested value are above the maximum value.
 		CannotSetAboveMax,
+		/// The requested round length must be at least the number of validators.
 		RoundLengthMustBeAtLeastTotalSelectedValidators,
+		/// The requested round length must be at least the number of created blocks.
 		RoundLengthMustBeLongerThanCreatedBlocks,
+		/// Cannot overwrite to the same value.
 		NoWritingSameValue,
+		/// Cannot join candidate pool due to too many candidates.
 		TooManyCandidates,
+		/// Cannot join candidate pool due to too low candidate count.
 		TooLowCandidateCountWeightHintJoinCandidates,
+		/// Cannot cancel leave candidate pool due to too low candidate count.
 		TooLowCandidateCountWeightHintCancelLeaveCandidates,
+		/// Cannot leave candidate pool due to too low candidate count.
 		TooLowCandidateCountToLeaveCandidates,
+		/// Cannot nominate due to too low nomination count.
 		TooLowNominationCountToNominate,
+		/// Cannot nominate due to too low candidate nomination count.
 		TooLowCandidateNominationCountToNominate,
+		/// Cannot leave candidate pool due to too low nomination count.
 		TooLowCandidateNominationCountToLeaveCandidates,
+		/// Cannot leave as a nominator due to too low nomination count.
 		TooLowNominationCountToLeaveNominators,
+		/// Pending(scheduled) candidate request does not exist.
 		PendingCandidateRequestsDNE,
+		/// A pending(scheduled) candidate request already exists.
 		PendingCandidateRequestAlreadyExists,
+		/// Cannot execute the pending(scheduled) candidate request yet.
 		PendingCandidateRequestNotDueYet,
+		/// Pending(scheduled) nomination request does not exist.
 		PendingNominationRequestDNE,
+		/// A pending(scheduled) nomination request already exists.
 		PendingNominationRequestAlreadyExists,
+		/// Cannot execute the pending(scheduled) nominator request yet.
 		PendingNominationRequestNotDueYet,
+		/// Cannot nominate if the given amount is less than the lowest bottom.
 		CannotNominateLessThanLowestBottomWhenBottomIsFull,
 	}
 
@@ -584,6 +636,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn delayed_commission_sets)]
+	/// Delayed candidate commission rate set requests
 	pub type DelayedCommissionSets<T: Config> = StorageMap<
 		_,
 		Twox64Concat,

--- a/pallets/bfc-staking/src/weights.rs
+++ b/pallets/bfc-staking/src/weights.rs
@@ -9,8 +9,6 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_bfc_staking.
 pub trait WeightInfo {
-	fn hotfix_remove_nomination_requests(x: u32) -> Weight;
-	fn hotfix_update_candidate_pool_value(x: u32) -> Weight;
 	fn set_staking_expectations() -> Weight;
 	fn set_inflation() -> Weight;
 	fn set_max_total_selected() -> Weight;
@@ -55,18 +53,6 @@ pub trait WeightInfo {
 /// Weights for pallet_bfc_staking using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn hotfix_remove_nomination_requests(x: u32) -> Weight {
-		Weight::from_ref_time(0)
-			.saturating_add(Weight::from_ref_time(8_132_000).saturating_mul(x as u64))
-			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(x as u64)))
-			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(x as u64)))
-	}
-	fn hotfix_update_candidate_pool_value(x: u32) -> Weight {
-		Weight::from_ref_time(0)
-			.saturating_add(Weight::from_ref_time(26_825_000).saturating_mul(x as u64))
-			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(x as u64)))
-			.saturating_add(T::DbWeight::get().writes(1 as u64))
-	}
 	fn set_staking_expectations() -> Weight {
 		Weight::from_ref_time(20_719_000)
 			.saturating_add(T::DbWeight::get().reads(5 as u64))
@@ -280,18 +266,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn hotfix_remove_nomination_requests(x: u32) -> Weight {
-		Weight::from_ref_time(0)
-			.saturating_add(Weight::from_ref_time(8_132_000).saturating_mul(x as u64))
-			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(x as u64)))
-			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(x as u64)))
-	}
-	fn hotfix_update_candidate_pool_value(x: u32) -> Weight {
-		Weight::from_ref_time(0)
-			.saturating_add(Weight::from_ref_time(26_825_000).saturating_mul(x as u64))
-			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(x as u64)))
-			.saturating_add(RocksDbWeight::get().writes(1 as u64))
-	}
 	fn set_staking_expectations() -> Weight {
 		Weight::from_ref_time(20_719_000)
 			.saturating_add(RocksDbWeight::get().reads(5 as u64))

--- a/pallets/bfc-utility/src/lib.rs
+++ b/pallets/bfc-utility/src/lib.rs
@@ -32,7 +32,7 @@ enum Releases {
 
 impl Default for Releases {
 	fn default() -> Self {
-		Releases::V1_0_0
+		Releases::V2_0_0
 	}
 }
 

--- a/pallets/bfc-utility/src/pallet/mod.rs
+++ b/pallets/bfc-utility/src/pallet/mod.rs
@@ -36,6 +36,7 @@ pub mod pallet {
 
 	#[pallet::error]
 	pub enum Error<T> {
+		/// The given amount is too low to process.
 		AmountTooLow,
 	}
 

--- a/pallets/bfc-utility/src/pallet/mod.rs
+++ b/pallets/bfc-utility/src/pallet/mod.rs
@@ -36,8 +36,7 @@ pub mod pallet {
 
 	#[pallet::error]
 	pub enum Error<T> {
-		FailedToMintNative,
-		AmountToLow,
+		AmountTooLow,
 	}
 
 	#[pallet::event]
@@ -113,13 +112,10 @@ pub mod pallet {
 			mint: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
 			T::MintableOrigin::ensure_origin(origin)?;
-			ensure!(!mint.is_zero(), Error::<T>::AmountToLow);
+			ensure!(!mint.is_zero(), Error::<T>::AmountTooLow);
 
-			if let Ok(minted) = T::Currency::deposit_into_existing(&beneficiary, mint) {
-				Self::deposit_event(Event::MintNative { beneficiary, minted: minted.peek() });
-			} else {
-				return Err((Error::<T>::FailedToMintNative).into())
-			}
+			let minted = T::Currency::deposit_creating(&beneficiary, mint);
+			Self::deposit_event(Event::MintNative { beneficiary, minted: minted.peek() });
 
 			Ok(().into())
 		}

--- a/pallets/bfc-utility/src/pallet/mod.rs
+++ b/pallets/bfc-utility/src/pallet/mod.rs
@@ -74,13 +74,14 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {
-			StorageVersion::<T>::put(Releases::V1_0_0);
+			StorageVersion::<T>::put(Releases::V2_0_0);
 			ProposalIndex::<T>::put(0);
 		}
 	}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::community_proposal())]
 		/// General Proposal
 		/// ####
@@ -103,6 +104,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::mint_native())]
 		/// Mint the exact amount of native tokens and deposit to the target address.
 		pub fn mint_native(

--- a/pallets/relay-manager/src/lib.rs
+++ b/pallets/relay-manager/src/lib.rs
@@ -78,7 +78,7 @@ pub struct RelayerMetadata<AccountId> {
 
 impl<AccountId: PartialEq + Clone> RelayerMetadata<AccountId> {
 	pub fn new(controller: AccountId) -> Self {
-		RelayerMetadata { controller, status: RelayerStatus::Active }
+		RelayerMetadata { controller, status: RelayerStatus::Idle }
 	}
 
 	pub fn go_offline(&mut self) {

--- a/pallets/relay-manager/src/lib.rs
+++ b/pallets/relay-manager/src/lib.rs
@@ -39,11 +39,12 @@ pub type IdentificationTuple<T> = (
 enum Releases {
 	V1_0_0,
 	V2_0_0,
+	V3_0_0,
 }
 
 impl Default for Releases {
 	fn default() -> Self {
-		Releases::V2_0_0
+		Releases::V3_0_0
 	}
 }
 
@@ -69,16 +70,25 @@ pub struct Relayer<AccountId> {
 
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
 /// The current state of a specific relayer
-pub struct RelayerMetadata<AccountId> {
+pub struct RelayerMetadata<AccountId, Hash> {
 	/// This relayer's bonded controller address
 	pub controller: AccountId,
 	/// This relayer's current status
 	pub status: RelayerStatus,
+	/// This relayer's implementation version
+	pub impl_version: Option<u32>,
+	/// This relayer's hashed spec version
+	pub spec_version: Option<Hash>,
 }
 
-impl<AccountId: PartialEq + Clone> RelayerMetadata<AccountId> {
+impl<AccountId: PartialEq + Clone, Hash> RelayerMetadata<AccountId, Hash> {
 	pub fn new(controller: AccountId) -> Self {
-		RelayerMetadata { controller, status: RelayerStatus::Idle }
+		RelayerMetadata {
+			controller,
+			status: RelayerStatus::Idle,
+			impl_version: None,
+			spec_version: None,
+		}
 	}
 
 	pub fn go_offline(&mut self) {
@@ -95,6 +105,14 @@ impl<AccountId: PartialEq + Clone> RelayerMetadata<AccountId> {
 
 	pub fn set_controller(&mut self, controller: AccountId) {
 		self.controller = controller;
+	}
+
+	pub fn set_impl_version(&mut self, impl_version: Option<u32>) {
+		self.impl_version = impl_version;
+	}
+
+	pub fn set_spec_version(&mut self, spec_version: Option<Hash>) {
+		self.spec_version = spec_version;
 	}
 
 	pub fn is_kicked_out(&self) -> bool {

--- a/pallets/relay-manager/src/lib.rs
+++ b/pallets/relay-manager/src/lib.rs
@@ -96,6 +96,10 @@ impl<AccountId: PartialEq + Clone> RelayerMetadata<AccountId> {
 	pub fn set_controller(&mut self, controller: AccountId) {
 		self.controller = controller;
 	}
+
+	pub fn is_kicked_out(&self) -> bool {
+		matches!(self.status, RelayerStatus::KickedOut)
+	}
 }
 
 #[derive(RuntimeDebug, TypeInfo)]

--- a/pallets/relay-manager/src/migrations.rs
+++ b/pallets/relay-manager/src/migrations.rs
@@ -1,5 +1,40 @@
 use super::*;
 
+pub mod v3 {
+	use super::*;
+	use frame_support::{pallet_prelude::Weight, traits::Get};
+
+	#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
+	pub struct OldRelayerState<AccountId> {
+		pub controller: AccountId,
+		pub status: RelayerStatus,
+	}
+
+	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
+		frame_support::ensure!(
+			StorageVersion::<T>::get() == Releases::V1_0_0 ||
+				StorageVersion::<T>::get() == Releases::V2_0_0,
+			"Storage version must match to v1.0.0 or v2.0.0",
+		);
+		log::info!("relay-manager storage migration passes pre-migrate checks ✅");
+		Ok(())
+	}
+
+	pub fn migrate<T: Config>() -> Weight {
+		RelayerState::<T>::translate(|_key, old: OldRelayerState<T::AccountId>| {
+			Some(RelayerMetadata {
+				controller: old.controller,
+				status: old.status,
+				impl_version: None,
+				spec_version: None,
+			})
+		});
+		StorageVersion::<T>::put(Releases::V3_0_0);
+		log::info!("relay-manager storage migration passes Releases::V3_0_0 update ✅");
+		T::BlockWeights::get().max_block
+	}
+}
+
 pub mod v2 {
 	use super::*;
 	use frame_support::{pallet_prelude::Weight, traits::Get};
@@ -13,12 +48,12 @@ pub mod v2 {
 	}
 
 	pub fn migrate<T: Config>() -> Weight {
-		RelayerPool::<T>::get().clone().into_iter().for_each(|r| {
-			RelayerState::<T>::insert(
-				&r.relayer,
-				RelayerMetadata { controller: r.controller, status: RelayerStatus::Active },
-			);
-		});
+		// RelayerPool::<T>::get().clone().into_iter().for_each(|r| {
+		// 	RelayerState::<T>::insert(
+		// 		&r.relayer,
+		// 		RelayerMetadata { controller: r.controller, status: RelayerStatus::Active },
+		// 	);
+		// });
 		IsHeartbeatOffenceActive::<T>::put(false);
 		HeartbeatSlashFraction::<T>::put(Perbill::from_percent(3));
 		StorageVersion::<T>::put(Releases::V2_0_0);

--- a/pallets/relay-manager/src/pallet/impls.rs
+++ b/pallets/relay-manager/src/pallet/impls.rs
@@ -28,8 +28,20 @@ where
 		Ok(().into())
 	}
 
+	fn refresh_relayer_pool() {
+		let pool = <RelayerPool<T>>::get();
+		pool.iter().for_each(|r| {
+			let mut relayer_state =
+				<RelayerState<T>>::get(&r.relayer).expect("RelayerState must exist");
+			relayer_state.go_offline();
+			<RelayerState<T>>::insert(&r.relayer, relayer_state);
+		});
+	}
+
 	fn refresh_selected_relayers(round: RoundIndex, selected_candidates: Vec<T::AccountId>) {
 		let mut selected_relayers = vec![];
+		Self::refresh_relayer_pool();
+
 		for controller in selected_candidates {
 			if let Some(relayer) = <BondedController<T>>::get(&controller) {
 				selected_relayers.push(relayer.clone());

--- a/pallets/relay-manager/src/pallet/mod.rs
+++ b/pallets/relay-manager/src/pallet/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 use frame_support::{pallet_prelude::*, traits::ValidatorSetWithIdentification, Twox64Concat};
 use frame_system::pallet_prelude::*;
 
-use bp_staking::{RoundIndex, MAX_VALIDATORS};
+use bp_staking::{RoundIndex, MAX_AUTHORITIES};
 use sp_runtime::Perbill;
 use sp_staking::{offence::ReportOffence, SessionIndex};
 use sp_std::prelude::*;
@@ -114,7 +114,7 @@ pub mod pallet {
 	#[pallet::getter(fn relayer_pool)]
 	/// The pool of relayers of the current round (including selected and non-selected relayers)
 	pub type RelayerPool<T: Config> =
-		StorageValue<_, BoundedVec<Relayer<T::AccountId>, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
+		StorageValue<_, BoundedVec<Relayer<T::AccountId>, ConstU32<MAX_AUTHORITIES>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn relayer_state)]
@@ -126,13 +126,13 @@ pub mod pallet {
 	#[pallet::getter(fn selected_relayers)]
 	/// The active relayer set selected for the current round
 	pub type SelectedRelayers<T: Config> =
-		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
+		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn initial_selected_relayers)]
 	/// The active relayer set selected at the beginning of the current round
 	pub type InitialSelectedRelayers<T: Config> =
-		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
+		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn cached_selected_relayers)]

--- a/pallets/relay-manager/src/pallet/mod.rs
+++ b/pallets/relay-manager/src/pallet/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 use frame_support::{pallet_prelude::*, traits::ValidatorSetWithIdentification, Twox64Concat};
 use frame_system::pallet_prelude::*;
 
-use bp_staking::RoundIndex;
+use bp_staking::{RoundIndex, MAX_VALIDATORS};
 use sp_runtime::Perbill;
 use sp_staking::{offence::ReportOffence, SessionIndex};
 use sp_std::prelude::*;
@@ -113,7 +113,8 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn relayer_pool)]
 	/// The pool of relayers of the current round (including selected and non-selected relayers)
-	pub type RelayerPool<T: Config> = StorageValue<_, Vec<Relayer<T::AccountId>>, ValueQuery>;
+	pub type RelayerPool<T: Config> =
+		StorageValue<_, BoundedVec<Relayer<T::AccountId>, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn relayer_state)]
@@ -124,12 +125,14 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn selected_relayers)]
 	/// The active relayer set selected for the current round
-	pub type SelectedRelayers<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+	pub type SelectedRelayers<T: Config> =
+		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn initial_selected_relayers)]
 	/// The active relayer set selected at the beginning of the current round
-	pub type InitialSelectedRelayers<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+	pub type InitialSelectedRelayers<T: Config> =
+		StorageValue<_, BoundedVec<T::AccountId, ConstU32<MAX_VALIDATORS>>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn cached_selected_relayers)]

--- a/pallets/relay-manager/src/pallet/mod.rs
+++ b/pallets/relay-manager/src/pallet/mod.rs
@@ -217,6 +217,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_storage_cache_lifetime())]
 		/// Set the `StorageCacheLifetime` round length
 		pub fn set_storage_cache_lifetime(
@@ -232,6 +233,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_heartbeat_offence_activation())]
 		/// Set the activation of relayer heartbeat management
 		pub fn set_heartbeat_offence_activation(
@@ -248,6 +250,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_heartbeat_slash_fraction())]
 		/// Set a new slash fraction for heartbeat offences
 		pub fn set_heartbeat_slash_fraction(
@@ -262,6 +265,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_relayer())]
 		/// (Re-)set the bonded relayer account. The origin must be the bonded controller account.
 		/// The state reflection will be immediately applied.
@@ -276,6 +280,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::heartbeat())]
 		/// DEPRECATED, this extrinsic will be removed later on. Please use `heartbeat_v2()`
 		/// instead. Sends a new heartbeat to manage relayer liveness for the current session. The
@@ -296,6 +301,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::heartbeat_v2())]
 		/// Sends a new heartbeat to manage relayer liveness for the current session. The origin
 		/// must be the registered relayer account, and only the selected relayers can request.

--- a/pallets/relay-manager/src/weights.rs
+++ b/pallets/relay-manager/src/weights.rs
@@ -14,6 +14,7 @@ pub trait WeightInfo {
 	fn set_heartbeat_slash_fraction() -> Weight;
 	fn set_relayer() -> Weight;
 	fn heartbeat() -> Weight;
+	fn heartbeat_v2() -> Weight;
 }
 
 /// Weights for `pallet_relay_manager` using the Substrate node and recommended hardware.
@@ -44,6 +45,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
+	fn heartbeat_v2() -> Weight {
+		Weight::from_ref_time(18_178_000)
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -69,6 +75,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	fn heartbeat() -> Weight {
+		Weight::from_ref_time(18_178_000)
+			.saturating_add(RocksDbWeight::get().reads(6 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
+	}
+	fn heartbeat_v2() -> Weight {
 		Weight::from_ref_time(18_178_000)
 			.saturating_add(RocksDbWeight::get().reads(6 as u64))
 			.saturating_add(RocksDbWeight::get().writes(4 as u64))

--- a/precompiles/bfc-staking/src/interface.sol
+++ b/precompiles/bfc-staking/src/interface.sol
@@ -136,6 +136,27 @@ interface BfcStaking {
         address[] calldata candidates
     ) external view returns (bool);
 
+    /// @dev Get the maximum seat capacity of each tier
+    /// Selector: 584eda98
+    /// @return The maximum seat capacity (full, basic)
+    function validator_seats() external view returns (uint256, uint256);
+
+    /// @dev Get the minimum required self-bond amount of each tier
+    /// Selector: b877ab9f
+    /// @return The minimum required self-bond amount (full, basic)
+    function candidate_minimum_self_bond()
+        external
+        view
+        returns (uint256, uint256);
+
+    /// @dev Get the minimum required voting power of each tier
+    /// Selector: 4f237d04
+    /// @return The minimum required voting power (full, basic)
+    function candidate_minimum_voting_power()
+        external
+        view
+        returns (uint256, uint256);
+
     /// @dev Get the current rounds info
     /// Selector: f8aa8ddd
     /// @return The current rounds index, first session index, current session index,

--- a/precompiles/bfc-staking/src/interface.sol
+++ b/precompiles/bfc-staking/src/interface.sol
@@ -137,12 +137,12 @@ interface BfcStaking {
     ) external view returns (bool);
 
     /// @dev Get the maximum seat capacity of each tier
-    /// Selector: 584eda98
+    /// Selector: 1b3b1bf9
     /// @return The maximum seat capacity (full, basic)
     function validator_seats() external view returns (uint256, uint256);
 
     /// @dev Get the minimum required self-bond amount of each tier
-    /// Selector: b877ab9f
+    /// Selector: 4165316b
     /// @return The minimum required self-bond amount (full, basic)
     function candidate_minimum_self_bond()
         external
@@ -150,7 +150,7 @@ interface BfcStaking {
         returns (uint256, uint256);
 
     /// @dev Get the minimum required voting power of each tier
-    /// Selector: 4f237d04
+    /// Selector: d2ae4e3f
     /// @return The minimum required voting power (full, basic)
     function candidate_minimum_voting_power()
         external

--- a/precompiles/bfc-staking/src/lib.rs
+++ b/precompiles/bfc-staking/src/lib.rs
@@ -294,6 +294,63 @@ where
 
 	// Common storage getters
 
+	#[precompile::public("validatorSeats()")]
+	#[precompile::public("validator_seats()")]
+	#[precompile::view]
+	fn validator_seats(handle: &mut impl PrecompileHandle) -> EvmResult<(U256, U256)> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+		let full_validator_seats: U256 = <StakingOf<Runtime>>::max_full_selected().into();
+		let basic_validator_seats: U256 = <StakingOf<Runtime>>::max_basic_selected().into();
+
+		Ok((full_validator_seats, basic_validator_seats))
+	}
+
+	#[precompile::public("candidateMinimumSelfBond()")]
+	#[precompile::public("candidate_minimum_self_bond()")]
+	#[precompile::view]
+	fn candidate_minimum_self_bond(handle: &mut impl PrecompileHandle) -> EvmResult<(U256, U256)> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+		let full_candidate_stk: U256 =
+			<<Runtime as pallet_bfc_staking::Config>::MinFullCandidateStk as Get<
+				BalanceOf<Runtime>,
+			>>::get()
+			.try_into()
+			.map_err(|_| revert("Amount is too large for provided balance type"))?;
+
+		let basic_candidate_stk: U256 =
+			<<Runtime as pallet_bfc_staking::Config>::MinBasicCandidateStk as Get<
+				BalanceOf<Runtime>,
+			>>::get()
+			.try_into()
+			.map_err(|_| revert("Amount is too large for provided balance type"))?;
+
+		Ok((full_candidate_stk, basic_candidate_stk))
+	}
+
+	#[precompile::public("candidateMinimumVotingPower()")]
+	#[precompile::public("candidate_minimum_voting_power()")]
+	#[precompile::view]
+	fn candidate_minimum_voting_power(
+		handle: &mut impl PrecompileHandle,
+	) -> EvmResult<(U256, U256)> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+		let full_validator_stk: U256 =
+			<<Runtime as pallet_bfc_staking::Config>::MinFullValidatorStk as Get<
+				BalanceOf<Runtime>,
+			>>::get()
+			.try_into()
+			.map_err(|_| revert("Amount is too large for provided balance type"))?;
+
+		let basic_validator_stk: U256 =
+			<<Runtime as pallet_bfc_staking::Config>::MinBasicValidatorStk as Get<
+				BalanceOf<Runtime>,
+			>>::get()
+			.try_into()
+			.map_err(|_| revert("Amount is too large for provided balance type"))?;
+
+		Ok((full_validator_stk, basic_validator_stk))
+	}
+
 	/// Returns the information of the current round
 	/// @return: The current rounds index, first session index, current session index,
 	///          first round block, first session block, current block, round length, session length

--- a/precompiles/bfc-staking/src/lib.rs
+++ b/precompiles/bfc-staking/src/lib.rs
@@ -712,9 +712,9 @@ where
 		let tier: u32 = tier.converted();
 
 		let raw_selected_candidates = match tier {
-			2 => StakingOf::<Runtime>::selected_full_candidates(),
-			1 => StakingOf::<Runtime>::selected_basic_candidates(),
-			_ => StakingOf::<Runtime>::selected_candidates(),
+			2 => StakingOf::<Runtime>::selected_full_candidates().into_inner(),
+			1 => StakingOf::<Runtime>::selected_basic_candidates().into_inner(),
+			_ => StakingOf::<Runtime>::selected_candidates().into_inner(),
 		};
 		let selected_candidates = raw_selected_candidates
 			.into_iter()
@@ -1486,9 +1486,9 @@ where
 			result = false;
 		} else {
 			let raw_selected_candidates = match tier {
-				TierType::Full => StakingOf::<Runtime>::selected_full_candidates(),
-				TierType::Basic => StakingOf::<Runtime>::selected_basic_candidates(),
-				TierType::All => StakingOf::<Runtime>::selected_candidates(),
+				TierType::Full => StakingOf::<Runtime>::selected_full_candidates().into_inner(),
+				TierType::Basic => StakingOf::<Runtime>::selected_basic_candidates().into_inner(),
+				TierType::All => StakingOf::<Runtime>::selected_candidates().into_inner(),
 			};
 			let selected_candidates = raw_selected_candidates
 				.into_iter()

--- a/precompiles/relay-manager/src/interface.sol
+++ b/precompiles/relay-manager/src/interface.sol
@@ -157,7 +157,11 @@ interface RelayManager {
             uint256[] memory
         );
 
-    /// @dev Sends a heartbeat that sets relayer unresponsiveness
+    /// @dev Sends a heartbeat that sets relayer liveness
     /// Selector: 3defb962
     function heartbeat() external;
+
+    /// @dev Sends a heartbeat that sets relayer liveness
+    /// Selector: e86ddbbd
+    function heartbeat_v2(uint256 impl_version, bytes32 spec_version) external;
 }

--- a/precompiles/relay-manager/src/lib.rs
+++ b/precompiles/relay-manager/src/lib.rs
@@ -470,4 +470,24 @@ where
 
 		Ok(())
 	}
+
+	#[precompile::public("heartbeatV2(uint256,bytes32)")]
+	#[precompile::public("heartbeat_v2(uint256,bytes32)")]
+	fn heartbeat_v2(
+		handle: &mut impl PrecompileHandle,
+		impl_version: SolidityConvert<U256, u32>,
+		spec_version: H256,
+	) -> EvmResult {
+		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
+
+		let impl_version: u32 = impl_version.converted();
+		let call = RelayManagerCall::<Runtime>::heartbeat_v2 {
+			impl_version,
+			spec_version: spec_version.into(),
+		};
+
+		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
+
+		Ok(())
+	}
 }

--- a/precompiles/relay-manager/src/types.rs
+++ b/precompiles/relay-manager/src/types.rs
@@ -40,7 +40,7 @@ where
 	pub fn set_state(
 		&mut self,
 		relayer: Runtime::AccountId,
-		state: RelayerMetadata<Runtime::AccountId>,
+		state: RelayerMetadata<Runtime::AccountId, Runtime::Hash>,
 	) {
 		self.relayer = Address(relayer.into());
 		self.controller = Address(state.controller.into());

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -15,7 +15,6 @@ pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// a dedicated type to prevent using arbitrary 20 byte arrays were AccountIds are expected. With
 /// the introduction of the `scale-info` crate this benefit extends even to non-Rust tools like
 /// Polkadot JS.
-
 #[derive(
 	Eq, PartialEq, Copy, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Default, PartialOrd, Ord,
 )]

--- a/primitives/bfc-staking/src/lib.rs
+++ b/primitives/bfc-staking/src/lib.rs
@@ -9,6 +9,8 @@ use sp_staking::SessionIndex;
 /// The type that indicates the index of a round
 pub type RoundIndex = u32;
 
+pub const MAX_VALIDATORS: u32 = 1_000;
+
 #[derive(Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Clone, Copy, RuntimeDebug, TypeInfo)]
 /// The tier type of a validator node.
 pub enum TierType {

--- a/primitives/bfc-staking/src/lib.rs
+++ b/primitives/bfc-staking/src/lib.rs
@@ -9,7 +9,7 @@ use sp_staking::SessionIndex;
 /// The type that indicates the index of a round
 pub type RoundIndex = u32;
 
-pub const MAX_VALIDATORS: u32 = 1_000;
+pub const MAX_AUTHORITIES: u32 = 1_000;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Clone, Copy, RuntimeDebug, TypeInfo)]
 /// The tier type of a validator node.

--- a/primitives/bfc-staking/src/lib.rs
+++ b/primitives/bfc-staking/src/lib.rs
@@ -9,6 +9,7 @@ use sp_staking::SessionIndex;
 /// The type that indicates the index of a round
 pub type RoundIndex = u32;
 
+/// The maximum authorities allowed
 pub const MAX_AUTHORITIES: u32 = 1_000;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Clone, Copy, RuntimeDebug, TypeInfo)]

--- a/primitives/bfc-staking/src/traits.rs
+++ b/primitives/bfc-staking/src/traits.rs
@@ -10,6 +10,9 @@ pub trait RelayManager<AccountId> {
 	/// Add the given `relayer` to the `RelayerPool` and bond to the given `controller` account
 	fn join_relayers(relayer: AccountId, controller: AccountId) -> Result<(), DispatchError>;
 
+	/// Refresh the relayers status to default.
+	fn refresh_relayer_pool();
+
 	/// Refresh the selected relayers based on the new selected candidates
 	fn refresh_selected_relayers(round: RoundIndex, selected_candidates: Vec<AccountId>);
 

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -110,7 +110,6 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	MigrateRelayManager,
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
@@ -690,15 +689,6 @@ impl pallet_relay_manager::Config for Runtime {
 	type IsHeartbeatOffenceActive = IsHeartbeatOffenceActive;
 	type DefaultHeartbeatSlashFraction = DefaultHeartbeatSlashFraction;
 	type WeightInfo = pallet_relay_manager::weights::SubstrateWeight<Runtime>;
-}
-
-pub struct MigrateRelayManager;
-impl frame_support::traits::OnRuntimeUpgrade for MigrateRelayManager {
-	fn on_runtime_upgrade() -> Weight {
-		pallet_relay_manager::migrations::v3::pre_migrate::<Runtime>().ok();
-		let weight = pallet_relay_manager::migrations::v3::migrate::<Runtime>();
-		weight
-	}
 }
 
 parameter_types! {

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -110,6 +110,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	MigrateRelayManager,
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
@@ -140,7 +141,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 280,
+	spec_version: 300,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.
@@ -689,6 +690,15 @@ impl pallet_relay_manager::Config for Runtime {
 	type IsHeartbeatOffenceActive = IsHeartbeatOffenceActive;
 	type DefaultHeartbeatSlashFraction = DefaultHeartbeatSlashFraction;
 	type WeightInfo = pallet_relay_manager::weights::SubstrateWeight<Runtime>;
+}
+
+pub struct MigrateRelayManager;
+impl frame_support::traits::OnRuntimeUpgrade for MigrateRelayManager {
+	fn on_runtime_upgrade() -> Weight {
+		pallet_relay_manager::migrations::v3::pre_migrate::<Runtime>().ok();
+		let weight = pallet_relay_manager::migrations::v3::migrate::<Runtime>();
+		weight
+	}
 }
 
 parameter_types! {

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -789,7 +789,7 @@ parameter_types! {
 	pub const BifrostChainId: u64 = 49088; // 0xbfc0
 	pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub WeightPerGas: Weight = Weight::from_ref_time(WEIGHT_PER_GAS);
-	pub PrecompilesValue: BifrostPrecompiles<Runtime> = BifrostPrecompiles::<_>::new();
+	pub PrecompilesValue: Precompiles = BifrostPrecompiles::<_>::new();
 }
 
 pub struct IntoAddressMapping;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -733,7 +733,7 @@ parameter_types! {
 	/// Minimum stake required to become a basic validator.
 	pub const MinBasicValidatorStk: u128 = 2_000_000 * SUPPLY_FACTOR * BFC;
 	/// Minimum stake required to be reserved to be a full candidate.
-	pub const MinFullCandidateStk: u128 = 300_000 * SUPPLY_FACTOR * BFC;
+	pub const MinFullCandidateStk: u128 = 400_000 * SUPPLY_FACTOR * BFC;
 	/// Minimum stake required to be reserved to be a basic candidate.
 	pub const MinBasicCandidateStk: u128 = 400_000 * SUPPLY_FACTOR * BFC;
 	/// Minimum stake required to be reserved to be a nominator.

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -110,6 +110,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	MigrateRelayManager,
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
@@ -141,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 2004,
+	spec_version: 2010,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.
@@ -689,6 +690,15 @@ impl pallet_relay_manager::Config for Runtime {
 	type IsHeartbeatOffenceActive = IsHeartbeatOffenceActive;
 	type DefaultHeartbeatSlashFraction = DefaultHeartbeatSlashFraction;
 	type WeightInfo = pallet_relay_manager::weights::SubstrateWeight<Runtime>;
+}
+
+pub struct MigrateRelayManager;
+impl frame_support::traits::OnRuntimeUpgrade for MigrateRelayManager {
+	fn on_runtime_upgrade() -> Weight {
+		pallet_relay_manager::migrations::v3::pre_migrate::<Runtime>().ok();
+		let weight = pallet_relay_manager::migrations::v3::migrate::<Runtime>();
+		weight
+	}
 }
 
 parameter_types! {

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -805,7 +805,7 @@ parameter_types! {
 	pub const BifrostChainId: u64 = 49088; // 0xbfc0
 	pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
 	pub WeightPerGas: Weight = Weight::from_ref_time(WEIGHT_PER_GAS);
-	pub PrecompilesValue: BifrostPrecompiles<Runtime> = BifrostPrecompiles::<_>::new();
+	pub PrecompilesValue: Precompiles = BifrostPrecompiles::<_>::new();
 }
 
 pub struct IntoAddressMapping;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -110,6 +110,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	MigrateRelayManager,
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
@@ -141,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 445,
+	spec_version: 450,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.
@@ -695,6 +696,15 @@ impl pallet_relay_manager::Config for Runtime {
 	type IsHeartbeatOffenceActive = IsHeartbeatOffenceActive;
 	type DefaultHeartbeatSlashFraction = DefaultHeartbeatSlashFraction;
 	type WeightInfo = pallet_relay_manager::weights::SubstrateWeight<Runtime>;
+}
+
+pub struct MigrateRelayManager;
+impl frame_support::traits::OnRuntimeUpgrade for MigrateRelayManager {
+	fn on_runtime_upgrade() -> Weight {
+		pallet_relay_manager::migrations::v3::pre_migrate::<Runtime>().ok();
+		let weight = pallet_relay_manager::migrations::v3::migrate::<Runtime>();
+		weight
+	}
 }
 
 parameter_types! {

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bifrost-platform/bifrost-node",
-  "version": "1.2.0-pre",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bifrost-platform/bifrost-node",
-      "version": "1.2.0-pre",
+      "version": "1.2.0",
       "dependencies": {
         "@polkadot/api": "9.10.5",
         "axios": "1.2.1",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bifrost-platform/bifrost-node",
-  "version": "1.2.0-pre",
+  "version": "1.2.0",
   "author": "bifrost-platform",
   "scripts": {
     "test": "mocha -r ts-node/register tests/**/**/*.ts --exit",

--- a/tests/tests/pallets/test_relay_manager.ts
+++ b/tests/tests/pallets/test_relay_manager.ts
@@ -190,7 +190,7 @@ describeDevNode('pallet_relay_manager - relayer heartbeat', (context) => {
     const rawRelayerState: any = await context.polkadotApi.query.relayManager.relayerState(charlethRelayer.address);
     const relayerState = rawRelayerState.unwrap().toJSON();
     expect(relayerState.controller).equal(charleth.address);
-    expect(relayerState.status).equal('Active');
+    expect(relayerState.status).equal('Idle');
 
     await context.polkadotApi.tx.relayManager.heartbeat()
       .signAndSend(charlethRelayer);

--- a/tests/tests/set_dev_node.ts
+++ b/tests/tests/set_dev_node.ts
@@ -106,7 +106,7 @@ export function describeDevNode(
         // We keep track of the polkadotApis to close them at the end of the test
         context._polkadotApis.push(apiPromise);
         await apiPromise.isReady;
-        await setTimeout(100);
+        await setTimeout(200);
         // Necessary hack to allow polkadotApi to finish its internal metadata loading
         // apiPromise.isReady unfortunately doesn't wait for those properly
         return apiPromise;

--- a/tests/tests/set_dev_node.ts
+++ b/tests/tests/set_dev_node.ts
@@ -106,7 +106,7 @@ export function describeDevNode(
         // We keep track of the polkadotApis to close them at the end of the test
         context._polkadotApis.push(apiPromise);
         await apiPromise.isReady;
-        await setTimeout(200);
+        await setTimeout(500);
         // Necessary hack to allow polkadotApi to finish its internal metadata loading
         // apiPromise.isReady unfortunately doesn't wait for those properly
         return apiPromise;

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bifrost-platform/bifrost-node",
-  "version": "1.2.0-pre",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bifrost-platform/bifrost-node",
-      "version": "1.2.0-pre",
+      "version": "1.2.0",
       "dependencies": {
         "@polkadot/api": "8.6.2",
         "axios": "0.27.2",

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bifrost-platform/bifrost-node",
-  "version": "1.2.0-pre",
+  "version": "1.2.0",
   "author": "bifrost-platform",
   "scripts": {
     "set_session_keys": "ts-node src/set_session_keys.ts",


### PR DESCRIPTION
## Description

This PR contains minor updates based by version `pre-v1.2.0`

### Changes
- Increase the minimum self-bond requirement for full nodes (mainnet only)
- Refresh the relayer status to `Idle` at every round update
- Add missing view functions for BfcStaking.sol precompiled contract
- Replace pallet storage values that consists `Vec` types to `BoundedVec` (length sensitive only)
- Introduce extrinsic `heartbeat_v2()` to `pallet_relay_manager` for relayer version tracking
- Use explicit call indices for custom pallets

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)
