### PR TITLE
NODE-20, payout nominator rewards in active state only

### DIFF
--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -1536,6 +1536,10 @@ impl<
 		matches!(self.status, NominatorStatus::Active)
 	}
 
+	pub fn is_revoking(&self, candidate: &AccountId) -> bool {
+		self.requests().get(candidate).is_some()
+	}
+
 	pub fn is_leaving(&self) -> bool {
 		matches!(self.status, NominatorStatus::Leaving(_))
 	}

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -1537,7 +1537,12 @@ impl<
 	}
 
 	pub fn is_revoking(&self, candidate: &AccountId) -> bool {
-		self.requests().get(candidate).is_some()
+		if let Some(request) = self.requests().get(candidate) {
+			if request.action == NominationChange::Revoke {
+				return true
+			}
+		}
+		false
 	}
 
 	pub fn is_leaving(&self) -> bool {

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -337,8 +337,8 @@ impl<T: Config> Pallet<T> {
 		reward: BalanceOf<T>,
 	) -> Result<(), DispatchError> {
 		if let Some(mut nominator_state) = <NominatorState<T>>::get(&nominator) {
-			// the nominator must not be revoking and leaving
-			if !nominator_state.is_revoking(&controller) && !nominator_state.is_leaving() {
+			// the nominator must be active and not revoking the current validator
+			if nominator_state.is_active() && !nominator_state.is_revoking(&controller) {
 				// mint rewards to the nominator account
 				Self::mint_reward(reward, nominator.clone());
 

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -695,7 +695,7 @@ parameter_types! {
 	/// Minimum round length is 30 seconds (10 * 3 second block times).
 	pub const MinBlocksPerRound: u32 = 1;
 	/// Blocks per round.
-	pub const DefaultBlocksPerRound: u32 = 2 * MINUTES;
+	pub const DefaultBlocksPerRound: u32 = 1 * MINUTES;
 	/// Rounds before the validator leaving the candidates request can be executed.
 	pub const LeaveCandidatesDelay: u32 = 1;
 	/// Rounds before the candidate bond increase/decrease can be executed.


### PR DESCRIPTION
## Description

- Nominator 보상 지급시, 해당 nominator의 status가 revoke 혹은 leave 상태가 아닌지 검증 후에 보상 지급을 진행한다.

### Changes
- `is_revoking()`: 해당 nominator가 주어진 candidate에게 revoke 요청을 보냈는지 검증 후에 참/거짓 반환
- 메소드명 변경
  - `handle_validator_auto_compounding()` -> `handle_validator_reward_payout()`
  -  `handle_nominator_auto_compounding()` -> `handle_nominator_reward_payout()`
- `pay_one_validator_reward()` 메소드 안에 존재했던 `mint` closure를 별도의 메소드로 추출 -> `mint_reward()`
- nominator 보상 지급시, status가 revoke 혹은 leave 상태가 아닌지 검증 후에 보상 지급 로직 실행

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [x] I have no personal secrets or credentials described on my changes.
- [x] I have run `cargo-clippy`  and linted my code.
- [x] My changes generate no new warnings.
- [x] My changes passed the existing test codes.
- [x] My changes are able to compile.
