### PR TITLE
NODE-79, bifrost pallets improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5687,6 +5687,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-serde 0.3.2",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",

--- a/pallets/bfc-offences/src/lib.rs
+++ b/pallets/bfc-offences/src/lib.rs
@@ -27,6 +27,22 @@ pub type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<
 	<T as frame_system::Config>::AccountId,
 >>::NegativeImbalance;
 
+pub(crate) const LOG_TARGET: &'static str = "runtime::bfc-offences";
+
+// syntactic sugar for logging.
+#[macro_export]
+macro_rules! log {
+	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+		log::$level!(
+			target: crate::LOG_TARGET,
+			concat!("[{:?}] 💸 ", $patter), <frame_system::Pallet<T>>::block_number() $(, $values)*
+		)
+	};
+}
+
+/// Used for release versioning upto v2_0_0.
+///
+/// Obsolete from v3. Keeping around to make encoding/decoding of old migration code easier.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 /// A value that represents the current storage version of this pallet.
 ///

--- a/pallets/bfc-offences/src/migrations.rs
+++ b/pallets/bfc-offences/src/migrations.rs
@@ -58,7 +58,7 @@ pub mod v2 {
 	use frame_support::{pallet_prelude::Weight, traits::Get};
 
 	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
-		frame_support::ensure!(
+		ensure!(
 			StorageVersion::<T>::get() == Releases::V1_0_0,
 			"Storage version must match to v1.0.0",
 		);
@@ -80,7 +80,7 @@ pub mod v1 {
 	use frame_support::{pallet_prelude::Weight, traits::Get};
 
 	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
-		frame_support::ensure!(
+		ensure!(
 			StorageVersion::<T>::get() == Releases::V1_0_0,
 			"Storage version must match to v1.0.0",
 		);

--- a/pallets/bfc-offences/src/migrations.rs
+++ b/pallets/bfc-offences/src/migrations.rs
@@ -1,4 +1,57 @@
 use super::*;
+use frame_support::{dispatch::Weight, pallet_prelude::*, storage_alias, traits::OnRuntimeUpgrade};
+
+#[storage_alias]
+pub type StorageVersion<T: Config> = StorageValue<Pallet<T>, Releases, ValueQuery>;
+
+pub mod v3 {
+	use super::*;
+	#[cfg(feature = "try-runtime")]
+	use sp_runtime::TryRuntimeError;
+
+	pub struct MigrateToV3<T>(PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV3<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let mut weight = Weight::zero();
+
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = StorageVersion::<T>::get();
+
+			if current == 3 && onchain == Releases::V2_0_0 {
+				StorageVersion::<T>::kill();
+				current.put::<Pallet<T>>();
+
+				log!(info, "bfc-offences storage migration passes v3 update ✅");
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 2));
+			} else {
+				log!(warn, "Skipping v3, should be removed");
+				weight = weight.saturating_add(T::DbWeight::get().reads(1));
+			}
+
+			weight
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			ensure!(
+				StorageVersion::<T>::get() == Releases::V2_0_0,
+				"Required v2_0_0 before upgrading to v3"
+			);
+
+			Ok(Default::default())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			ensure!(Pallet::<T>::on_chain_storage_version() == 3, "v3 not applied");
+
+			ensure!(!StorageVersion::<T>::exists(), "Storage version not migrated correctly");
+
+			Ok(())
+		}
+	}
+}
 
 pub mod v2 {
 	use super::*;

--- a/pallets/bfc-offences/src/migrations.rs
+++ b/pallets/bfc-offences/src/migrations.rs
@@ -19,6 +19,7 @@ pub mod v3 {
 			let onchain = StorageVersion::<T>::get();
 
 			if current == 3 && onchain == Releases::V2_0_0 {
+				// migrate to new standard storage version
 				StorageVersion::<T>::kill();
 				current.put::<Pallet<T>>();
 

--- a/pallets/bfc-offences/src/pallet/mod.rs
+++ b/pallets/bfc-offences/src/pallet/mod.rs
@@ -127,7 +127,6 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {
-			// StorageVersion::<T>::put(Releases::V2_0_0);
 			OffenceExpirationInSessions::<T>::put(T::DefaultOffenceExpirationInSessions::get());
 			FullMaximumOffenceCount::<T>::put(T::DefaultFullMaximumOffenceCount::get());
 			BasicMaximumOffenceCount::<T>::put(T::DefaultBasicMaximumOffenceCount::get());

--- a/pallets/bfc-offences/src/pallet/mod.rs
+++ b/pallets/bfc-offences/src/pallet/mod.rs
@@ -109,7 +109,7 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		fn on_runtime_upgrade() -> Weight {
 			migrations::v3::MigrateToV3::<T>::on_runtime_upgrade()
 		}
 	}
@@ -147,7 +147,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: SessionIndex,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(new > 0u32, Error::<T>::CannotSetBelowMin);
 			let old = <OffenceExpirationInSessions<T>>::get();
 			ensure!(old != new, Error::<T>::NoWritingSameValue);
@@ -166,7 +166,7 @@ pub mod pallet {
 			new: OffenceCount,
 			tier: TierType,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(new > 0u32, Error::<T>::CannotSetBelowMin);
 			match tier {
 				TierType::Full => {
@@ -214,7 +214,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			is_active: bool,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(is_active != <IsOffenceActive<T>>::get(), Error::<T>::NoWritingSameValue);
 			<IsOffenceActive<T>>::put(is_active);
 			Self::deposit_event(Event::OffenceActivationSet { is_active });
@@ -230,7 +230,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			is_active: bool,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(is_active != <IsSlashActive<T>>::get(), Error::<T>::NoWritingSameValue);
 			<IsSlashActive<T>>::put(is_active);
 			Self::deposit_event(Event::SlashActivationSet { is_active });

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -1225,15 +1225,13 @@ impl<
 		let mut in_top = false;
 		top_nominations.nominations = top_nominations
 			.nominations
-			.clone()
 			.into_iter()
 			.map(|d| {
-				if d.owner != nominator {
-					d
-				} else {
+				if d.owner == nominator {
 					in_top = true;
-					let new_amount = d.amount.saturating_add(more);
-					Bond { owner: d.owner, amount: new_amount }
+					Bond { owner: d.owner, amount: d.amount.saturating_add(more) }
+				} else {
+					d
 				}
 			})
 			.collect();
@@ -1301,14 +1299,13 @@ impl<
 			// just increase the nomination
 			bottom_nominations.nominations = bottom_nominations
 				.nominations
-				.clone()
 				.into_iter()
 				.map(|d| {
-					if d.owner != nominator {
-						d
-					} else {
+					if d.owner == nominator {
 						in_bottom = true;
 						Bond { owner: d.owner, amount: d.amount.saturating_add(more) }
+					} else {
+						d
 					}
 				})
 				.collect();
@@ -1414,14 +1411,13 @@ impl<
 			let mut is_in_top = false;
 			top_nominations.nominations = top_nominations
 				.nominations
-				.clone()
 				.into_iter()
 				.map(|d| {
-					if d.owner != nominator {
-						d
-					} else {
+					if d.owner == nominator {
 						is_in_top = true;
 						Bond { owner: d.owner, amount: d.amount.saturating_sub(less) }
+					} else {
+						d
 					}
 				})
 				.collect();
@@ -1450,14 +1446,13 @@ impl<
 		let mut in_bottom = false;
 		bottom_nominations.nominations = bottom_nominations
 			.nominations
-			.clone()
 			.into_iter()
 			.map(|d| {
-				if d.owner != nominator {
-					d
-				} else {
+				if d.owner == nominator {
 					in_bottom = true;
 					Bond { owner: d.owner, amount: d.amount.saturating_sub(less) }
+				} else {
+					d
 				}
 			})
 			.collect();

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -1635,13 +1635,14 @@ impl<
 		candidate: AccountId,
 		amount: Balance,
 	) -> DispatchResult {
-		if let Some(_) = self.nominations.insert(candidate.clone(), amount) {
+		if self.nominations.contains_key(&candidate) {
+			Err(<Error<T>>::AlreadyNominatedCandidate.into())
+		} else {
+			self.nominations.insert(candidate.clone(), amount);
 			self.total += amount;
 			self.initial_nominations.insert(candidate.clone(), amount);
-			self.awarded_tokens_per_candidate.insert(candidate.clone(), Zero::zero());
+			self.awarded_tokens_per_candidate.insert(candidate, Zero::zero());
 			Ok(())
-		} else {
-			Err(<Error<T>>::AlreadyNominatedCandidate.into())
 		}
 	}
 

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -125,37 +125,6 @@ impl<A: Decode, B: Default> Default for Bond<A, B> {
 	}
 }
 
-impl<A: Ord + Clone, B: Zero + Ord + Copy + Clone> From<CandidateBond<A, B>> for Bond<A, B> {
-	fn from(candidate_bond: CandidateBond<A, B>) -> Self {
-		Self { owner: candidate_bond.owner, amount: candidate_bond.amount }
-	}
-}
-
-#[derive(
-	Eq, PartialEq, PartialOrd, Ord, Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen,
-)]
-/// Same as `Bond<AccountId, Balance>`. Only difference is order by amount.
-pub struct CandidateBond<AccountId, Balance> {
-	pub amount: Balance,
-	pub owner: AccountId,
-}
-
-impl<A: Decode, B: Default> Default for CandidateBond<A, B> {
-	fn default() -> CandidateBond<A, B> {
-		CandidateBond {
-			amount: B::default(),
-			owner: A::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())
-				.expect("infinite length input; no invalid inputs for type; qed"),
-		}
-	}
-}
-
-impl<A: Ord + Clone, B: Zero + Ord + Copy + Clone> From<Bond<A, B>> for CandidateBond<A, B> {
-	fn from(bond: Bond<A, B>) -> Self {
-		Self { amount: bond.amount, owner: bond.owner }
-	}
-}
-
 #[derive(
 	Eq,
 	PartialEq,

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -454,8 +454,8 @@ impl<
 	> Nominations<AccountId, Balance>
 {
 	/// Retrieve the nominator accounts as a vector
-	pub fn nominators(self) -> Vec<AccountId> {
-		self.nominations.into_iter().map(|n| n.owner).collect()
+	pub fn nominators(&self) -> Vec<AccountId> {
+		self.nominations.iter().map(|n| n.owner.clone()).collect()
 	}
 
 	pub fn count(&self) -> u32 {

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -79,6 +79,10 @@ macro_rules! log {
 	};
 }
 
+/// Used for release versioning upto v3_0_0.
+///
+/// Obsolete from v4. Keeping around to make encoding/decoding of old migration code easier.
+
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 /// A value placed in storage that represents the current version of the Staking storage. This value
 /// is used by the `on_runtime_upgrade` logic to determine whether we run storage migration logic.
@@ -372,7 +376,7 @@ impl<AccountId: PartialEq + Clone> DelayedControllerSet<AccountId> {
 }
 
 #[derive(Default, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-/// Info needed to maked delayed commission sets after round end
+/// Info needed to made delayed commission sets after round end
 pub struct DelayedCommissionSet<AccountId> {
 	/// The bonded controller account
 	pub who: AccountId,
@@ -1271,8 +1275,7 @@ impl<
 		let mut bottom_nominations =
 			<BottomNominations<T>>::get(candidate).ok_or(Error::<T>::CandidateDNE)?;
 		let mut nomination_option: Option<Bond<T::AccountId, BalanceOf<T>>> = None;
-		let in_top_after = if (bond.saturating_add(more)).into() > self.lowest_top_nomination_amount
-		{
+		let in_top_after = if bond.saturating_add(more).into() > self.lowest_top_nomination_amount {
 			// bump it from bottom
 			bottom_nominations.nominations = bottom_nominations
 				.nominations

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -567,12 +567,10 @@ impl<
 		nominator: &AccountId,
 		value: Balance,
 	) -> bool {
-		for (i, bond) in &mut self.nominations.iter().enumerate() {
+		for bond in self.nominations.iter_mut() {
 			if bond.owner == *nominator {
-				let new = Bond { owner: bond.owner.clone(), amount: bond.amount - value };
-				self.nominations[i] = new;
+				bond.amount = bond.amount.saturating_sub(value);
 				self.total = self.total.saturating_sub(value);
-
 				return true;
 			}
 		}

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -1629,15 +1629,19 @@ impl<
 		self.status = NominatorStatus::Active
 	}
 
-	pub fn add_nomination(&mut self, bond: Bond<AccountId, Balance>) -> bool {
-		let amt = bond.amount;
-		if let Some(_) = self.nominations.insert(bond.owner.clone(), bond.amount) {
-			self.total += amt;
-			self.initial_nominations.insert(bond.owner.clone(), bond.amount);
-			self.awarded_tokens_per_candidate.insert(bond.owner.clone(), Zero::zero());
-			true
+	// pub fn add_nomination(&mut self, bond: Bond<AccountId, Balance>) -> bool {
+	pub fn add_nomination<T: Config>(
+		&mut self,
+		candidate: AccountId,
+		amount: Balance,
+	) -> DispatchResult {
+		if let Some(_) = self.nominations.insert(candidate.clone(), amount) {
+			self.total += amount;
+			self.initial_nominations.insert(candidate.clone(), amount);
+			self.awarded_tokens_per_candidate.insert(candidate.clone(), Zero::zero());
+			Ok(())
 		} else {
-			false
+			Err(<Error<T>>::AlreadyNominatedCandidate.into())
 		}
 	}
 

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -125,6 +125,37 @@ impl<A: Decode, B: Default> Default for Bond<A, B> {
 	}
 }
 
+impl<A: Ord + Clone, B: Zero + Ord + Copy + Clone> From<CandidateBond<A, B>> for Bond<A, B> {
+	fn from(candidate_bond: CandidateBond<A, B>) -> Self {
+		Self { owner: candidate_bond.owner, amount: candidate_bond.amount }
+	}
+}
+
+#[derive(
+	Eq, PartialEq, PartialOrd, Ord, Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen,
+)]
+/// Same as `Bond<AccountId, Balance>`. Only difference is order by amount.
+pub struct CandidateBond<AccountId, Balance> {
+	pub amount: Balance,
+	pub owner: AccountId,
+}
+
+impl<A: Decode, B: Default> Default for CandidateBond<A, B> {
+	fn default() -> CandidateBond<A, B> {
+		CandidateBond {
+			amount: B::default(),
+			owner: A::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())
+				.expect("infinite length input; no invalid inputs for type; qed"),
+		}
+	}
+}
+
+impl<A: Ord + Clone, B: Zero + Ord + Copy + Clone> From<Bond<A, B>> for CandidateBond<A, B> {
+	fn from(bond: Bond<A, B>) -> Self {
+		Self { amount: bond.amount, owner: bond.owner }
+	}
+}
+
 #[derive(
 	Eq,
 	PartialEq,

--- a/pallets/bfc-staking/src/lib.rs
+++ b/pallets/bfc-staking/src/lib.rs
@@ -40,7 +40,6 @@ pub mod weights;
 
 pub use inflation::{InflationInfo, Range};
 pub use pallet::pallet::*;
-pub use set::OrderedSet;
 use weights::WeightInfo;
 
 use parity_scale_codec::{Decode, Encode};

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::set::OrderedSet;
 
 pub mod v4 {
 	use super::*;

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -13,6 +13,10 @@ pub mod v4 {
 
 	#[storage_alias]
 	pub type StorageVersion<T: Config> = StorageValue<Pallet<T>, Releases, ValueQuery>;
+
+	#[storage_alias]
+	pub type MinTotalSelected<T: Config> = StorageValue<Pallet<T>, u32, ValueQuery>;
+
 	#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
 	/// Nominator state
 	pub struct OrderedSetNominator<AccountId, Balance> {
@@ -32,6 +36,9 @@ pub mod v4 {
 	impl<T: Config> OnRuntimeUpgrade for MigrateToV4<T> {
 		fn on_runtime_upgrade() -> Weight {
 			let mut weight = Weight::zero();
+
+			MinTotalSelected::<T>::kill();
+			weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 1));
 
 			<CandidatePool<T>>::translate::<
 				BoundedVec<Bond<T::AccountId, BalanceOf<T>>, ConstU32<MAX_AUTHORITIES>>,

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -151,24 +151,6 @@ pub mod v4 {
 					},
 				);
 
-				// translate `Vec<(RoundIndex, BTreeSet<T::AccountId>)>` to `BTreeMap<RoundIndex, BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>>>`
-				<CachedSelectedCandidates<T>>::translate::<
-					Vec<(RoundIndex, BTreeSet<T::AccountId>)>,
-					_,
-				>(|old| {
-					Some(
-						old.expect("")
-							.into_iter()
-							.map(|(index, set)| (index, BoundedBTreeSet::try_from(set).expect("")))
-							.collect::<BTreeMap<
-								RoundIndex,
-								BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>>,
-							>>(),
-					)
-				})
-				.expect("");
-				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
-
 				// translate `Vec<(RoundIndex, u32)>` to `BTreeMap<RoundIndex, u32>`
 				<CachedMajority<T>>::translate::<Vec<(RoundIndex, u32)>, _>(|old| {
 					Some(old.expect("").into_iter().collect::<BTreeMap<RoundIndex, u32>>())

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -31,8 +31,10 @@ pub mod v4 {
 		fn on_runtime_upgrade() -> Weight {
 			let mut weight = Weight::zero();
 
-			NominatorState::<T>::translate(
+			<NominatorState<T>>::translate(
 				|_, old: OrderedSetNominator<T::AccountId, BalanceOf<T>>| {
+					weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+
 					let nominations: BTreeMap<_, _> = old
 						.nominations
 						.0

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -1,5 +1,60 @@
 use super::*;
 
+pub mod v4 {
+	use super::*;
+	use frame_support::storage_alias;
+	use frame_support::traits::OnRuntimeUpgrade;
+
+	#[cfg(feature = "try-runtime")]
+	use sp_runtime::TryRuntimeError;
+
+	#[storage_alias]
+	pub type StorageVersion<T: Config> = StorageValue<Pallet<T>, Releases, ValueQuery>;
+
+	pub struct MigrateToV4<T>(PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV4<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let mut weight = Weight::zero();
+
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = StorageVersion::<T>::get();
+
+			if current == 4 && onchain == Releases::V3_0_0 {
+				StorageVersion::<T>::kill();
+				current.put::<Pallet<T>>();
+
+				log!(info, "v4 applied successfully");
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 2));
+			} else {
+				log!(warn, "Skipping v4, should be removed");
+				weight = weight.saturating_add(T::DbWeight::get().reads(1));
+			}
+
+			weight
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			ensure!(
+				StorageVersion::<T>::get() == Releases::V3_0_0,
+				"Required v3_0_0 before upgrading to v4"
+			);
+
+			Ok(Default::default())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			ensure!(Pallet::<T>::on_chain_storage_version() == 4, "v4 not applied");
+
+			ensure!(!StorageVersion::<T>::exists(), "Storage version not migrated correctly");
+
+			Ok(())
+		}
+	}
+}
+
 pub mod v3 {
 	use super::*;
 	// use frame_support::traits::Get;

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -109,13 +109,16 @@ pub mod v4 {
 					let nominations: BTreeMap<_, _> = old
 						.nominations
 						.0
-						.clone()
-						.iter()
-						.map(|bond| (bond.owner.clone(), bond.amount))
+						.into_iter()
+						.map(|bond| (bond.owner, bond.amount))
 						.collect();
 
-					let initial_nominations: BTreeSet<_> =
-						old.initial_nominations.0.clone().into_iter().collect();
+					let initial_nominations: BTreeMap<_, _> = old
+						.initial_nominations
+						.0
+						.into_iter()
+						.map(|bond| (bond.owner, bond.amount))
+						.collect();
 
 					let awarded_tokens_per_candidate: BTreeMap<_, _> = old
 						.awarded_tokens_per_candidate

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -24,10 +24,10 @@ pub mod v4 {
 				StorageVersion::<T>::kill();
 				current.put::<Pallet<T>>();
 
-				log!(info, "v4 applied successfully");
+				log!(info, "bfc-staking storage migration passes v4 update ✅");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 2));
 			} else {
-				log!(warn, "Skipping v4, should be removed");
+				log!(warn, "Skipping bfc-staking migration v4, should be removed");
 				weight = weight.saturating_add(T::DbWeight::get().reads(1));
 			}
 

--- a/pallets/bfc-staking/src/migrations.rs
+++ b/pallets/bfc-staking/src/migrations.rs
@@ -44,6 +44,7 @@ pub mod v4 {
 				MinTotalSelected::<T>::kill();
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 1));
 
+				// translate `BoundedVec<Bond<T::AccountId, BalanceOf<T>>, ConstU32<MAX_AUTHORITIES>>` to `BoundedBTreeMap<T::AccountId, BalanceOf<T>, ConstU32<MAX_AUTHORITIES>>`
 				<CandidatePool<T>>::translate::<
 					BoundedVec<Bond<T::AccountId, BalanceOf<T>>, ConstU32<MAX_AUTHORITIES>>,
 					_,
@@ -59,6 +60,7 @@ pub mod v4 {
 				.expect("");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
+				// closure for translate `BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>` to `BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>>`
 				let vec_to_bset =
 					|old: Option<BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>>| {
 						let new: BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>> = old
@@ -86,6 +88,7 @@ pub mod v4 {
 				.expect("");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 3));
 
+				// translate `Vec<(RoundIndex, Vec<T::AccountId>)>` to `BTreeMap<RoundIndex, BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>>>`
 				<CachedSelectedCandidates<T>>::translate::<Vec<(RoundIndex, Vec<T::AccountId>)>, _>(
 					|old| {
 						Some(
@@ -107,6 +110,7 @@ pub mod v4 {
 					.expect("");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
+				// translate old `Nominator` which using ordered set to new Nominator
 				<NominatorState<T>>::translate(
 					|_, old: OrderedSetNominator<T::AccountId, BalanceOf<T>>| {
 						weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
@@ -147,6 +151,7 @@ pub mod v4 {
 					},
 				);
 
+				// translate `Vec<(RoundIndex, BTreeSet<T::AccountId>)>` to `BTreeMap<RoundIndex, BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>>>`
 				<CachedSelectedCandidates<T>>::translate::<
 					Vec<(RoundIndex, BTreeSet<T::AccountId>)>,
 					_,
@@ -164,14 +169,17 @@ pub mod v4 {
 				.expect("");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
+				// translate `Vec<(RoundIndex, u32)>` to `BTreeMap<RoundIndex, u32>`
 				<CachedMajority<T>>::translate::<Vec<(RoundIndex, u32)>, _>(|old| {
 					Some(old.expect("").into_iter().collect::<BTreeMap<RoundIndex, u32>>())
 				})
 				.expect("");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
+				// migrate to new standard storage version
 				StorageVersion::<T>::kill();
 				current.put::<Pallet<T>>();
+
 				log!(info, "bfc-staking storage migration passes v4 update ✅");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 2));
 			} else {

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -748,20 +748,22 @@ impl<T: Config> Pallet<T> {
 	/// Refresh the latest rounds cached selected candidates to the current state
 	fn refresh_latest_cached_selected_candidates() {
 		<CachedSelectedCandidates<T>>::mutate(|cached_selected_candidates| {
+			let candidates = Self::selected_candidates();
 			cached_selected_candidates
 				.entry(Self::round().current_round_index)
-				.and_modify(|candidates| *candidates = Self::selected_candidates())
-				.or_insert(Self::selected_candidates());
+				.and_modify(|c| *c = candidates.clone())
+				.or_insert(candidates);
 		});
 	}
 
 	/// Refresh the latest rounds cached majority to the current state
 	fn refresh_latest_cached_majority() {
 		<CachedMajority<T>>::mutate(|cached_majority| {
+			let majority = Self::majority();
 			cached_majority
 				.entry(Self::round().current_round_index)
-				.and_modify(|majority| *majority = Self::majority())
-				.or_insert(Self::majority());
+				.and_modify(|m| *m = majority)
+				.or_insert(majority);
 		});
 	}
 

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -453,7 +453,7 @@ impl<T: Config> Pallet<T> {
 					// replace `TopNominations`
 					if let Some(top_nominations) = <TopNominations<T>>::take(&c.old) {
 						Self::replace_nominator_nominations(
-							&top_nominations.clone().nominators(),
+							&top_nominations.nominators(),
 							&c.old,
 							&c.new,
 						);
@@ -462,7 +462,7 @@ impl<T: Config> Pallet<T> {
 					// replace `BottomNominations`
 					if let Some(bottom_nominations) = <BottomNominations<T>>::get(&c.old) {
 						Self::replace_nominator_nominations(
-							&bottom_nominations.clone().nominators(),
+							&bottom_nominations.nominators(),
 							&c.old,
 							&c.new,
 						);

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -455,7 +455,7 @@ impl<T: Config> Pallet<T> {
 						<TopNominations<T>>::insert(&c.new, top_nominations);
 					}
 					// replace `BottomNominations`
-					if let Some(bottom_nominations) = <BottomNominations<T>>::get(&c.old) {
+					if let Some(bottom_nominations) = <BottomNominations<T>>::take(&c.old) {
 						Self::replace_nominator_nominations(
 							&bottom_nominations.nominators(),
 							&c.old,

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -633,13 +633,6 @@ impl<T: Config> Pallet<T> {
 				.expect("all members of CandidateQ must be candidates");
 			let top_nominations = Self::top_nominations(validator)
 				.expect("all members of CandidateQ must be candidates");
-			let bottom_nominations = BottomNominations::<T>::get(validator)
-				.expect("all members of CandidateQ must be candidates");
-
-			// Nominators for each validator
-			let mut nominators = vec![];
-			nominators.append(&mut top_nominations.nominations.clone());
-			nominators.append(&mut bottom_nominations.nominations.clone());
 
 			validator_count += 1u32;
 			nomination_count += state.nomination_count;

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -624,13 +624,12 @@ impl<T: Config> Pallet<T> {
 		mut candidates: Vec<Bond<T::AccountId, BalanceOf<T>>>,
 	) -> Vec<T::AccountId> {
 		// order full candidates by voting power (least to greatest so requires `rev()`)
-		candidates.sort_by(|a, b| a.amount.cmp(&b.amount));
+		candidates.sort_by(|a, b| b.amount.cmp(&a.amount));
 		let top_n = <MaxFullSelected<T>>::get() as usize;
 
 		// choose the top MaxFullSelected qualified candidates, ordered by voting power
 		let mut validators = candidates
 			.into_iter()
-			.rev()
 			.filter(|x| x.amount >= T::MinFullValidatorStk::get())
 			.take(top_n)
 			.map(|x| x.owner)

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -86,11 +86,15 @@ impl<T: Config> Pallet<T> {
 		new: T::AccountId,
 	) -> DispatchResult {
 		let round = <Round<T>>::get();
-		let mut controller_sets = <DelayedControllerSets<T>>::get(round.current_round_index);
-		controller_sets
-			.try_push(DelayedControllerSet::new(stash, old, new))
-			.map_err(|_| <Error<T>>::TooManyDelayedControllers)?;
-		<DelayedControllerSets<T>>::insert(round.current_round_index, controller_sets);
+		<DelayedControllerSets<T>>::try_mutate(
+			round.current_round_index,
+			|controller_sets| -> DispatchResult {
+				controller_sets
+					.try_push(DelayedControllerSet::new(stash, old, new))
+					.map_err(|_| <Error<T>>::TooManyDelayedControllers)?;
+				Ok(())
+			},
+		)?;
 		Ok(())
 	}
 

--- a/pallets/bfc-staking/src/pallet/impls.rs
+++ b/pallets/bfc-staking/src/pallet/impls.rs
@@ -89,13 +89,11 @@ impl<T: Config> Pallet<T> {
 		<DelayedControllerSets<T>>::try_mutate(
 			round.current_round_index,
 			|controller_sets| -> DispatchResult {
-				controller_sets
+				Ok(controller_sets
 					.try_push(DelayedControllerSet::new(stash, old, new))
-					.map_err(|_| <Error<T>>::TooManyDelayedControllers)?;
-				Ok(())
+					.map_err(|_| <Error<T>>::TooManyDelayedControllers)?)
 			},
-		)?;
-		Ok(())
+		)
 	}
 
 	/// Adds a new commission set request. The state reflection will be applied in the next round.
@@ -108,14 +106,11 @@ impl<T: Config> Pallet<T> {
 		<DelayedCommissionSets<T>>::try_mutate(
 			round.current_round_index,
 			|commission_sets| -> DispatchResult {
-				commission_sets
+				Ok(commission_sets
 					.try_push(DelayedCommissionSet::new(who.clone(), old, new))
-					.map_err(|_| <Error<T>>::TooManyDelayedCommissions)?;
-				Ok(())
+					.map_err(|_| <Error<T>>::TooManyDelayedCommissions)?)
 			},
-		)?;
-
-		Ok(())
+		)
 	}
 
 	/// Remove the given `who` from the `DelayedControllerSets` of the current round.
@@ -763,10 +758,9 @@ impl<T: Config> Pallet<T> {
 	/// Refresh the latest rounds cached majority to the current state
 	fn refresh_latest_cached_majority() {
 		let round = Self::round();
-		let majority = Self::majority();
 		<CachedMajority<T>>::mutate(|cached_majority| {
 			cached_majority.retain(|r| r.0 != round.current_round_index);
-			cached_majority.push((round.current_round_index, majority));
+			cached_majority.push((round.current_round_index, Self::majority()));
 		});
 	}
 

--- a/pallets/bfc-staking/src/pallet/mod.rs
+++ b/pallets/bfc-staking/src/pallet/mod.rs
@@ -2,9 +2,9 @@ mod impls;
 
 use crate::{
 	migrations, BalanceOf, BlockNumberOf, Bond, CandidateMetadata, DelayedCommissionSet,
-	DelayedControllerSet, DelayedPayout, InflationInfo, NominationChange, NominationRequest,
-	Nominations, Nominator, NominatorAdded, Range, RewardDestination, RewardPoint, RoundIndex,
-	RoundInfo, TierType, TotalSnapshot, ValidatorSnapshot, WeightInfo,
+	DelayedControllerSet, DelayedPayout, InflationInfo, NominationRequest, Nominations, Nominator,
+	NominatorAdded, Range, RewardDestination, RewardPoint, RoundIndex, RoundInfo, TierType,
+	TotalSnapshot, ValidatorSnapshot, WeightInfo,
 };
 
 use bp_staking::{
@@ -14,7 +14,7 @@ use bp_staking::{
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
 	pallet_prelude::*,
-	traits::{Currency, Get, ReservableCurrency, StorageVersion, OnRuntimeUpgrade},
+	traits::{Currency, Get, OnRuntimeUpgrade, ReservableCurrency, StorageVersion},
 	Twox64Concat,
 };
 use frame_system::pallet_prelude::*;
@@ -1320,14 +1320,7 @@ pub mod pallet {
 					if remaining.is_zero() {
 						<NominatorState<T>>::remove(&bond.owner);
 					} else {
-						if let Some(request) = nominator.requests.requests.remove(&controller) {
-							nominator.requests.less_total =
-								nominator.requests.less_total.saturating_sub(request.amount);
-							if matches!(request.action, NominationChange::Revoke) {
-								nominator.requests.revocations_count =
-									nominator.requests.revocations_count.saturating_sub(1u32);
-							}
-						}
+						nominator.requests.remove_request(&controller);
 						<NominatorState<T>>::insert(&bond.owner, nominator);
 					}
 				}

--- a/pallets/bfc-staking/src/pallet/mod.rs
+++ b/pallets/bfc-staking/src/pallet/mod.rs
@@ -710,7 +710,7 @@ pub mod pallet {
 			weight
 		}
 
-		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		fn on_runtime_upgrade() -> Weight {
 			migrations::v4::MigrateToV4::<T>::on_runtime_upgrade()
 		}
 	}
@@ -911,7 +911,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::set_max_total_selected())]
 		/// Set the maximum number of full validator candidates selected per round
 		pub fn set_max_full_selected(origin: OriginFor<T>, new: u32) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(new >= <MinTotalSelected<T>>::get(), Error::<T>::CannotSetBelowMin);
 			let old = <MaxFullSelected<T>>::get();
 			ensure!(old != new, Error::<T>::NoWritingSameValue);
@@ -932,7 +932,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: u32,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(new >= <MinTotalSelected<T>>::get(), Error::<T>::CannotSetBelowMin);
 			let old = <MaxBasicSelected<T>>::get();
 			ensure!(old != new, Error::<T>::NoWritingSameValue);
@@ -953,7 +953,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: u32,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(new <= <MaxTotalSelected<T>>::get(), Error::<T>::CannotSetAboveMax);
 			let old = <MinTotalSelected<T>>::get();
 			ensure!(old != new, Error::<T>::NoWritingSameValue);
@@ -974,7 +974,7 @@ pub mod pallet {
 			new: Perbill,
 			tier: TierType,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			match tier {
 				TierType::Full => {
 					let old = <DefaultFullValidatorCommission<T>>::get();
@@ -1029,7 +1029,7 @@ pub mod pallet {
 			new: Perbill,
 			tier: TierType,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			match tier {
 				TierType::Full => {
 					let old = <MaxFullValidatorCommission<T>>::get();
@@ -1157,7 +1157,7 @@ pub mod pallet {
 		/// - the `new` round length will be updated immediately in the next block
 		/// - also updates per-round inflation config
 		pub fn set_blocks_per_round(origin: OriginFor<T>, new: u32) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(new >= T::MinBlocksPerRound::get(), Error::<T>::CannotSetBelowMin);
 			let mut round = <Round<T>>::get();
 			let (current_round, now, first, old) = (
@@ -1200,7 +1200,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: u32,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(new >= 1u32, Error::<T>::CannotSetBelowOne);
 			let old = <StorageCacheLifetime<T>>::get();
 			ensure!(old != new, Error::<T>::NoWritingSameValue);

--- a/pallets/bfc-staking/src/pallet/mod.rs
+++ b/pallets/bfc-staking/src/pallet/mod.rs
@@ -1157,7 +1157,7 @@ pub mod pallet {
 			);
 			ensure!(old != new, Error::<T>::NoWritingSameValue);
 			ensure!(
-				now - first < T::BlockNumber::from(new),
+				now - first < T::BlockNumber::from(new as u8),
 				Error::<T>::RoundLengthMustBeLongerThanCreatedBlocks,
 			);
 			ensure!(
@@ -1646,11 +1646,11 @@ pub mod pallet {
 				// nomination after first
 				ensure!(amount >= T::MinNomination::get(), Error::<T>::NominationBelowMin);
 				ensure!(
-					nomination_count >= state.nominations.0.len() as u32,
+					nomination_count >= state.nominations.len() as u32,
 					Error::<T>::TooLowNominationCountToNominate
 				);
 				ensure!(
-					(state.nominations.0.len() as u32) < T::MaxNominationsPerNominator::get(),
+					(state.nominations.len() as u32) < T::MaxNominationsPerNominator::get(),
 					Error::<T>::ExceedMaxNominationsPerNominator
 				);
 				ensure!(
@@ -1723,11 +1723,11 @@ pub mod pallet {
 			let nominator = ensure_signed(origin)?;
 			let state = <NominatorState<T>>::get(&nominator).ok_or(Error::<T>::NominatorDNE)?;
 			state.can_execute_leave::<T>(nomination_count)?;
-			for bond in state.nominations.0 {
+			for bond in state.nominations {
 				if let Err(error) = Self::nominator_leaves_candidate(
-					bond.owner.clone(),
+					bond.0.clone(),
 					nominator.clone(),
-					bond.amount,
+					bond.1,
 				) {
 					log::warn!(
 						"STORAGE CORRUPTED \nNominator leaving validator failed with error: {:?}",

--- a/pallets/bfc-staking/src/pallet/mod.rs
+++ b/pallets/bfc-staking/src/pallet/mod.rs
@@ -1471,18 +1471,12 @@ pub mod pallet {
 			selected_candidates.remove(&controller);
 			// refresh selected candidates
 			let round = <Round<T>>::get().current_round_index;
-			Self::refresh_cached_selected_candidates(
-				round,
-				selected_candidates.clone(),
-			);
+			Self::refresh_cached_selected_candidates(round, selected_candidates.clone());
 			// refresh majority
 			let majority: u32 = Self::compute_majority();
 			<Majority<T>>::put(majority);
 			let mut cached_majority = <CachedMajority<T>>::get();
-			cached_majority
-				.entry(round)
-				.and_modify(|m| *m = majority)
-				.or_insert(majority);
+			cached_majority.entry(round).and_modify(|m| *m = majority).or_insert(majority);
 			<CachedMajority<T>>::put(cached_majority);
 			if state.tier == TierType::Full {
 				// kickout relayer
@@ -1625,10 +1619,7 @@ pub mod pallet {
 					(state.nominations.len() as u32) < T::MaxNominationsPerNominator::get(),
 					Error::<T>::ExceedMaxNominationsPerNominator
 				);
-				ensure!(
-					state.add_nomination(Bond { owner: candidate.clone(), amount }),
-					Error::<T>::AlreadyNominatedCandidate
-				);
+				state.add_nomination::<T>(candidate.clone(), amount)?;
 				state
 			} else {
 				// first nomination

--- a/pallets/bfc-staking/src/pallet/mod.rs
+++ b/pallets/bfc-staking/src/pallet/mod.rs
@@ -726,7 +726,6 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			// StorageVersion::<T>::put(Releases::V3_0_0);
 			<InflationConfig<T>>::put(self.inflation_config.clone());
 			// Set validator commission to default config
 			<DefaultFullValidatorCommission<T>>::put(T::DefaultFullValidatorCommission::get());

--- a/pallets/bfc-utility/Cargo.toml
+++ b/pallets/bfc-utility/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+log = { workspace = true }
 serde = { workspace = true, optional = true }
 impl-serde = { workspace = true }
 
@@ -32,17 +33,17 @@ sp-io = { workspace = true, features = ["std"] }
 [features]
 default = ["std"]
 std = [
-	"impl-serde/std",
-	"scale-info/std",
-	"parity-scale-codec/std",
-	"frame-benchmarking/std",
-	"frame-support/std",
-	"frame-system/std",
-	"serde",
-	"sp-runtime/std",
-	"sp-std/std",
-	"sp-core/std",
-	"sp-io/std",
+    "impl-serde/std",
+    "scale-info/std",
+    "parity-scale-codec/std",
+    "frame-benchmarking/std",
+    "frame-support/std",
+    "frame-system/std",
+    "serde",
+    "sp-runtime/std",
+    "sp-std/std",
+    "sp-core/std",
+    "sp-io/std",
 ]
 runtime-benchmarks = ["frame-benchmarking"]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/bfc-utility/src/lib.rs
+++ b/pallets/bfc-utility/src/lib.rs
@@ -21,6 +21,22 @@ pub type BalanceOf<T> =
 /// The type that indicates the index of a general proposal
 pub type PropIndex = u32;
 
+pub(crate) const LOG_TARGET: &'static str = "runtime::bfc-utility";
+
+// syntactic sugar for logging.
+#[macro_export]
+macro_rules! log {
+	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+		log::$level!(
+			target: crate::LOG_TARGET,
+			concat!("[{:?}] 💸 ", $patter), <frame_system::Pallet<T>>::block_number() $(, $values)*
+		)
+	};
+}
+
+/// Used for release versioning upto v2_0_0.
+///
+/// Obsolete from v3. Keeping around to make encoding/decoding of old migration code easier.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 /// A value placed in storage that represents the current version of the BFC Utility storage. This
 /// value is used by the `on_runtime_upgrade` logic to determine whether we run storage migration

--- a/pallets/bfc-utility/src/migrations.rs
+++ b/pallets/bfc-utility/src/migrations.rs
@@ -1,5 +1,57 @@
 use super::*;
-use frame_support::pallet_prelude::Weight;
+use frame_support::{pallet_prelude::*, storage_alias, traits::OnRuntimeUpgrade};
+
+#[storage_alias]
+pub type StorageVersion<T: Config> = StorageValue<Pallet<T>, Releases, ValueQuery>;
+
+pub mod v3 {
+	use super::*;
+	#[cfg(feature = "try-runtime")]
+	use sp_runtime::TryRuntimeError;
+
+	pub struct MigrateToV3<T>(PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV3<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let mut weight = Weight::zero();
+
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = StorageVersion::<T>::get();
+
+			if current == 3 && onchain == Releases::V2_0_0 {
+				StorageVersion::<T>::kill();
+				current.put::<Pallet<T>>();
+
+				log!(info, "bfc-utility storage migration passes v3 update ✅");
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 2));
+			} else {
+				log!(warn, "Skipping v3, should be removed");
+				weight = weight.saturating_add(T::DbWeight::get().reads(1));
+			}
+
+			weight
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			ensure!(
+				StorageVersion::<T>::get() == Releases::V2_0_0,
+				"Required v2_0_0 before upgrading to v3"
+			);
+
+			Ok(Default::default())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			ensure!(Pallet::<T>::on_chain_storage_version() == 3, "v3 not applied");
+
+			ensure!(!StorageVersion::<T>::exists(), "Storage version not migrated correctly");
+
+			Ok(())
+		}
+	}
+}
 
 pub mod v2 {
 	use super::*;

--- a/pallets/bfc-utility/src/migrations.rs
+++ b/pallets/bfc-utility/src/migrations.rs
@@ -19,6 +19,7 @@ pub mod v3 {
 			let onchain = StorageVersion::<T>::get();
 
 			if current == 3 && onchain == Releases::V2_0_0 {
+				// migrate to new standard storage version
 				StorageVersion::<T>::kill();
 				current.put::<Pallet<T>>();
 

--- a/pallets/bfc-utility/src/pallet/mod.rs
+++ b/pallets/bfc-utility/src/pallet/mod.rs
@@ -61,7 +61,7 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		fn on_runtime_upgrade() -> Weight {
 			migrations::v3::MigrateToV3::<T>::on_runtime_upgrade()
 		}
 	}

--- a/pallets/relay-manager/src/lib.rs
+++ b/pallets/relay-manager/src/lib.rs
@@ -33,6 +33,22 @@ pub type IdentificationTuple<T> = (
 	>>::Identification,
 );
 
+pub(crate) const LOG_TARGET: &'static str = "runtime::relay-manager";
+
+// syntactic sugar for logging.
+#[macro_export]
+macro_rules! log {
+	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+		log::$level!(
+			target: crate::LOG_TARGET,
+			concat!("[{:?}] 💸 ", $patter), <frame_system::Pallet<T>>::block_number() $(, $values)*
+		)
+	};
+}
+
+/// Used for release versioning upto v3_0_0.
+///
+/// Obsolete from v4. Keeping around to make encoding/decoding of old migration code easier.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 /// A value placed in storage that represents the current version of the Relay Manager storage. This
 /// value is used by the `on_runtime_upgrade` logic to determine whether we run storage migration

--- a/pallets/relay-manager/src/lib.rs
+++ b/pallets/relay-manager/src/lib.rs
@@ -72,7 +72,7 @@ pub enum RelayerStatus {
 	Active,
 	/// It is offline due to unsending heartbeats for the current session
 	Idle,
-	/// It is kicked out due to continueing unresponsiveness
+	/// It is kicked out due to continuing unresponsiveness
 	KickedOut,
 }
 

--- a/pallets/relay-manager/src/migrations.rs
+++ b/pallets/relay-manager/src/migrations.rs
@@ -39,6 +39,7 @@ pub mod v4 {
 				_,
 			>(old_selected_to_new)
 			.expect("");
+			weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
 
 			let old_cache_to_new = |old: Option<Vec<(RoundIndex, Vec<T::AccountId>)>>| {
 				let new: BTreeMap<
@@ -64,6 +65,17 @@ pub mod v4 {
 			)
 			.expect("");
 			<CachedInitialSelectedRelayers<T>>::translate::<Vec<(RoundIndex, Vec<T::AccountId>)>, _>(old_cache_to_new).expect("");
+			weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
+
+			let old_cache_to_new =
+				|old: Option<Vec<(RoundIndex, u32)>>| -> Option<BTreeMap<RoundIndex, u32>> {
+					Some(old.expect("").into_iter().collect::<BTreeMap<RoundIndex, u32>>())
+				};
+			<CachedMajority<T>>::translate::<Vec<(RoundIndex, u32)>, _>(old_cache_to_new)
+				.expect("");
+			<CachedInitialMajority<T>>::translate::<Vec<(RoundIndex, u32)>, _>(old_cache_to_new)
+				.expect("");
+			weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
 
 			let current = Pallet::<T>::current_storage_version();
 			let onchain = StorageVersion::<T>::get();

--- a/pallets/relay-manager/src/migrations.rs
+++ b/pallets/relay-manager/src/migrations.rs
@@ -23,6 +23,7 @@ pub mod v4 {
 			let onchain = StorageVersion::<T>::get();
 
 			if current == 4 && onchain == Releases::V3_0_0 {
+				// closure for translate old selected relayers format to new selected relayers format
 				let old_selected_to_new =
 					|old: Option<BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>>| {
 						let new: BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>> = old
@@ -45,6 +46,7 @@ pub mod v4 {
 				.expect("");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
 
+				// closure for translate old Cached*SelectedRelayers format to new Cached*SelectedRelayers format
 				let old_cache_to_new = |old: Option<Vec<(RoundIndex, Vec<T::AccountId>)>>| {
 					let new: BTreeMap<
 						RoundIndex,
@@ -75,6 +77,7 @@ pub mod v4 {
 				.expect("");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
 
+				// closure for translate old Cached*Majority format to new Cached*Majority format
 				let old_cache_to_new =
 					|old: Option<Vec<(RoundIndex, u32)>>| -> Option<BTreeMap<RoundIndex, u32>> {
 						Some(old.expect("").into_iter().collect::<BTreeMap<RoundIndex, u32>>())
@@ -87,6 +90,7 @@ pub mod v4 {
 				.expect("");
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
 
+				// migrate to new standard storage version
 				StorageVersion::<T>::kill();
 				current.put::<Pallet<T>>();
 

--- a/pallets/relay-manager/src/migrations.rs
+++ b/pallets/relay-manager/src/migrations.rs
@@ -1,4 +1,58 @@
 use super::*;
+use frame_support::{pallet_prelude::*, storage_alias, traits::OnRuntimeUpgrade};
+
+#[storage_alias]
+pub type StorageVersion<T: Config> = StorageValue<Pallet<T>, Releases, ValueQuery>;
+
+pub mod v4 {
+	use super::*;
+
+	#[cfg(feature = "try-runtime")]
+	use sp_runtime::TryRuntimeError;
+
+	pub struct MigrateToV4<T>(PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV4<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let mut weight = Weight::zero();
+
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = StorageVersion::<T>::get();
+
+			if current == 4 && onchain == Releases::V3_0_0 {
+				StorageVersion::<T>::kill();
+				current.put::<Pallet<T>>();
+
+				log!(info, "relay-manager storage migration passes v4 update ✅");
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 2));
+			} else {
+				log!(warn, "Skipping v4, should be removed");
+				weight = weight.saturating_add(T::DbWeight::get().reads(1));
+			}
+
+			weight
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			ensure!(
+				StorageVersion::<T>::get() == Releases::V3_0_0,
+				"Required v3_0_0 before upgrading to v4"
+			);
+
+			Ok(Default::default())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			ensure!(Pallet::<T>::on_chain_storage_version() == 4, "v4 not applied");
+
+			ensure!(!StorageVersion::<T>::exists(), "Storage version not migrated correctly");
+
+			Ok(())
+		}
+	}
+}
 
 pub mod v3 {
 	use super::*;

--- a/pallets/relay-manager/src/migrations.rs
+++ b/pallets/relay-manager/src/migrations.rs
@@ -19,68 +19,74 @@ pub mod v4 {
 		fn on_runtime_upgrade() -> Weight {
 			let mut weight = Weight::zero();
 
-			let old_selected_to_new =
-				|old: Option<BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>>| {
-					let new: BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>> = old
-						.expect("")
-						.into_iter()
-						.collect::<BTreeSet<T::AccountId>>()
-						.try_into()
-						.expect("");
-					Some(new)
-				};
-			<SelectedRelayers<T>>::translate::<
-				BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>,
-				_,
-			>(old_selected_to_new)
-			.expect("");
-			<InitialSelectedRelayers<T>>::translate::<
-				BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>,
-				_,
-			>(old_selected_to_new)
-			.expect("");
-			weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
-
-			let old_cache_to_new = |old: Option<Vec<(RoundIndex, Vec<T::AccountId>)>>| {
-				let new: BTreeMap<
-					RoundIndex,
-					BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>>,
-				> = old.expect("")
-					.into_iter()
-					.map(|(round_index, vec_ids)| {
-						let set_ids: BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>> =
-							vec_ids
-								.into_iter()
-								.collect::<BTreeSet<T::AccountId>>()
-								.try_into()
-								.expect("");
-						(round_index, set_ids)
-					})
-					.collect();
-
-				Some(new)
-			};
-			<CachedSelectedRelayers<T>>::translate::<Vec<(RoundIndex, Vec<T::AccountId>)>, _>(
-				old_cache_to_new,
-			)
-			.expect("");
-			<CachedInitialSelectedRelayers<T>>::translate::<Vec<(RoundIndex, Vec<T::AccountId>)>, _>(old_cache_to_new).expect("");
-			weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
-
-			let old_cache_to_new =
-				|old: Option<Vec<(RoundIndex, u32)>>| -> Option<BTreeMap<RoundIndex, u32>> {
-					Some(old.expect("").into_iter().collect::<BTreeMap<RoundIndex, u32>>())
-				};
-			<CachedMajority<T>>::translate::<Vec<(RoundIndex, u32)>, _>(old_cache_to_new)
-				.expect("");
-			<CachedInitialMajority<T>>::translate::<Vec<(RoundIndex, u32)>, _>(old_cache_to_new)
-				.expect("");
-			weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
-
 			let current = Pallet::<T>::current_storage_version();
 			let onchain = StorageVersion::<T>::get();
 
 			if current == 4 && onchain == Releases::V3_0_0 {
+				let old_selected_to_new =
+					|old: Option<BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>>| {
+						let new: BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>> = old
+							.expect("")
+							.into_iter()
+							.collect::<BTreeSet<T::AccountId>>()
+							.try_into()
+							.expect("");
+						Some(new)
+					};
+				<SelectedRelayers<T>>::translate::<
+					BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>,
+					_,
+				>(old_selected_to_new)
+				.expect("");
+				<InitialSelectedRelayers<T>>::translate::<
+					BoundedVec<T::AccountId, ConstU32<MAX_AUTHORITIES>>,
+					_,
+				>(old_selected_to_new)
+				.expect("");
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
+
+				let old_cache_to_new = |old: Option<Vec<(RoundIndex, Vec<T::AccountId>)>>| {
+					let new: BTreeMap<
+						RoundIndex,
+						BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>>,
+					> = old.expect("")
+						.into_iter()
+						.map(|(round_index, vec_ids)| {
+							let set_ids: BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>> =
+								vec_ids
+									.into_iter()
+									.collect::<BTreeSet<T::AccountId>>()
+									.try_into()
+									.expect("");
+							(round_index, set_ids)
+						})
+						.collect();
+
+					Some(new)
+				};
+				<CachedSelectedRelayers<T>>::translate::<Vec<(RoundIndex, Vec<T::AccountId>)>, _>(
+					old_cache_to_new,
+				)
+				.expect("");
+				<CachedInitialSelectedRelayers<T>>::translate::<
+					Vec<(RoundIndex, Vec<T::AccountId>)>,
+					_,
+				>(old_cache_to_new)
+				.expect("");
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
+
+				let old_cache_to_new =
+					|old: Option<Vec<(RoundIndex, u32)>>| -> Option<BTreeMap<RoundIndex, u32>> {
+						Some(old.expect("").into_iter().collect::<BTreeMap<RoundIndex, u32>>())
+					};
+				<CachedMajority<T>>::translate::<Vec<(RoundIndex, u32)>, _>(old_cache_to_new)
+					.expect("");
+				<CachedInitialMajority<T>>::translate::<Vec<(RoundIndex, u32)>, _>(
+					old_cache_to_new,
+				)
+				.expect("");
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
+
 				StorageVersion::<T>::kill();
 				current.put::<Pallet<T>>();
 

--- a/pallets/relay-manager/src/pallet/impls.rs
+++ b/pallets/relay-manager/src/pallet/impls.rs
@@ -14,7 +14,7 @@ use sp_std::{vec, vec::Vec};
 impl<T: Config> RelayManager<T::AccountId> for Pallet<T>
 where
 	<T as frame_system::Config>::AccountId: From<
-		<<T as pallet::Config>::ValidatorSet as ValidatorSet<
+		<<T as Config>::ValidatorSet as ValidatorSet<
 			<T as frame_system::Config>::AccountId,
 		>>::ValidatorId,
 	>,

--- a/pallets/relay-manager/src/pallet/impls.rs
+++ b/pallets/relay-manager/src/pallet/impls.rs
@@ -6,6 +6,7 @@ use bp_staking::{traits::RelayManager, RoundIndex};
 use frame_support::{
 	pallet_prelude::*,
 	traits::{ValidatorSet, ValidatorSetWithIdentification},
+	BoundedBTreeSet,
 };
 use sp_runtime::traits::Convert;
 use sp_staking::offence::ReportOffence;
@@ -19,20 +20,20 @@ where
 		>>::ValidatorId,
 	>,
 {
-	fn join_relayers(relayer: T::AccountId, controller: T::AccountId) -> Result<(), DispatchError> {
+	fn join_relayers(relayer: T::AccountId, controller: T::AccountId) -> DispatchResult {
 		Self::verify_relayer_existence(&relayer, &controller)?;
-		Self::add_to_relayer_pool(relayer.clone(), controller.clone());
+		Self::add_to_relayer_pool(relayer.clone(), controller.clone())?;
 		<RelayerState<T>>::insert(&relayer, RelayerMetadata::new(controller.clone()));
 		<BondedController<T>>::insert(&controller, relayer.clone());
 		Self::deposit_event(Event::JoinedRelayers { relayer, controller });
-		Ok(().into())
+		Ok(())
 	}
 
 	fn refresh_relayer_pool() {
-		let pool = <RelayerPool<T>>::get();
+		let pool = Self::relayer_pool();
 		pool.iter().for_each(|r| {
 			let mut relayer_state =
-				<RelayerState<T>>::get(&r.relayer).expect("RelayerState must exist");
+				Self::relayer_state(&r.relayer).expect("RelayerState must exist");
 			if !relayer_state.is_kicked_out() {
 				relayer_state.go_offline();
 			}
@@ -41,57 +42,51 @@ where
 	}
 
 	fn refresh_selected_relayers(round: RoundIndex, selected_candidates: Vec<T::AccountId>) {
-		let mut selected_relayers = vec![];
+		let mut selected_relayers: BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>> = Default::default();
 		Self::refresh_relayer_pool();
 
 		for controller in selected_candidates {
-			if let Some(relayer) = <BondedController<T>>::get(&controller) {
-				selected_relayers.push(relayer.clone());
+			if let Some(relayer) = Self::bonded_controller(&controller) {
+				selected_relayers.try_insert(relayer.clone()).expect(<Error<T>>::TooManySelectedRelayers.as_str());
 				let mut relayer_state =
-					<RelayerState<T>>::get(&relayer).expect("RelayerState must exist");
+					Self::relayer_state(&relayer).expect("RelayerState must exist");
 				relayer_state.go_online();
 				<RelayerState<T>>::insert(&relayer, relayer_state);
 				Self::deposit_event(Event::RelayerChosen {
 					round,
-					relayer: relayer.clone(),
+					relayer,
 					controller,
 				});
 			}
 		}
 		<Round<T>>::put(round);
-		selected_relayers.sort();
-		<SelectedRelayers<T>>::put(
-			BoundedVec::try_from(selected_relayers.clone()).expect("SelectedRelayers out of bound"),
-		);
-		<InitialSelectedRelayers<T>>::put(
-			BoundedVec::try_from(selected_relayers.clone())
-				.expect("InitialSelectedRelayers out of bound"),
-		);
-		Self::refresh_cached_selected_relayers(round, selected_relayers.clone());
+		<SelectedRelayers<T>>::put(selected_relayers.clone());
+		<InitialSelectedRelayers<T>>::put(selected_relayers.clone());
+		Self::refresh_cached_selected_relayers(round, selected_relayers);
 	}
 
-	fn refresh_cached_selected_relayers(round: RoundIndex, relayers: Vec<T::AccountId>) {
-		let mut cached_selected_relayers = <CachedSelectedRelayers<T>>::get();
-		let mut cached_initial_selected_relayers = <CachedInitialSelectedRelayers<T>>::get();
-		if <StorageCacheLifetime<T>>::get() <= cached_selected_relayers.len() as u32 {
-			cached_selected_relayers.remove(0);
+	fn refresh_cached_selected_relayers(round: RoundIndex, relayers: BoundedBTreeSet<T::AccountId, ConstU32<MAX_AUTHORITIES>>) {
+		let mut cached_selected_relayers = Self::cached_selected_relayers();
+		let mut cached_initial_selected_relayers = Self::cached_initial_selected_relayers();
+		if Self::storage_cache_lifetime() <= cached_selected_relayers.len() as u32 {
+			cached_selected_relayers.pop_first();
 		}
-		if <StorageCacheLifetime<T>>::get() <= cached_initial_selected_relayers.len() as u32 {
-			cached_initial_selected_relayers.remove(0);
+		if Self::storage_cache_lifetime() <= cached_initial_selected_relayers.len() as u32 {
+			cached_initial_selected_relayers.pop_first();
 		}
-		cached_selected_relayers.push((round, relayers.clone()));
-		cached_initial_selected_relayers.push((round, relayers.clone()));
+		cached_selected_relayers.insert(round, relayers.clone());
+		cached_initial_selected_relayers.insert(round, relayers.clone());
 		<CachedSelectedRelayers<T>>::put(cached_selected_relayers);
 		<CachedInitialSelectedRelayers<T>>::put(cached_initial_selected_relayers);
 	}
 
 	fn refresh_majority(round: RoundIndex) {
-		let mut cached_majority = <CachedMajority<T>>::get();
-		let mut cached_initial_majority = <CachedInitialMajority<T>>::get();
-		if <StorageCacheLifetime<T>>::get() <= cached_majority.len() as u32 {
+		let mut cached_majority = Self::cached_majority();
+		let mut cached_initial_majority = Self::cached_initial_majority();
+		if Self::storage_cache_lifetime() <= cached_majority.len() as u32 {
 			cached_majority.remove(0);
 		}
-		if <StorageCacheLifetime<T>>::get() <= cached_initial_majority.len() as u32 {
+		if Self::storage_cache_lifetime() <= cached_initial_majority.len() as u32 {
 			cached_initial_majority.remove(0);
 		}
 		let majority: u32 = Self::compute_majority();
@@ -107,11 +102,11 @@ where
 		if let Some(relayer) = <BondedController<T>>::take(&old) {
 			<BondedController<T>>::insert(&new, relayer.clone());
 			let mut relayer_state =
-				<RelayerState<T>>::get(&relayer).expect("RelayerState must exist");
+				Self::relayer_state(&relayer).expect("RelayerState must exist");
 			relayer_state.set_controller(new.clone());
 			<RelayerState<T>>::insert(&relayer, relayer_state);
 			Self::remove_from_relayer_pool(&new, false);
-			Self::add_to_relayer_pool(relayer.clone(), new.clone());
+			Self::add_to_relayer_pool(relayer.clone(), new.clone()).expect(<Error<T>>::TooManyRelayers.as_str());
 		}
 	}
 
@@ -123,9 +118,9 @@ where
 	}
 
 	fn kickout_relayer(controller: &T::AccountId) {
-		if let Some(relayer) = <BondedController<T>>::get(controller) {
+		if let Some(relayer) = Self::bonded_controller(controller) {
 			let mut relayer_state =
-				<RelayerState<T>>::get(&relayer).expect("RelayerState must exist");
+				Self::relayer_state(&relayer).expect("RelayerState must exist");
 			relayer_state.kick_out();
 			<RelayerState<T>>::insert(&relayer, relayer_state);
 
@@ -160,7 +155,7 @@ where
 				let relayer =
 					Self::bonded_controller(&controller).expect("BondedController must exist");
 				let mut relayer_state =
-					<RelayerState<T>>::get(&relayer).expect("RelayerState must exist");
+					Self::relayer_state(&relayer).expect("RelayerState must exist");
 				relayer_state.go_offline();
 				<RelayerState<T>>::insert(&relayer, relayer_state);
 				<T::ValidatorSet as ValidatorSetWithIdentification<T::AccountId>>::IdentificationOf::convert(
@@ -177,7 +172,7 @@ where
 		if offenders.is_empty() {
 			Self::deposit_event(Event::<T>::AllGood);
 		} else {
-			if <IsHeartbeatOffenceActive<T>>::get() {
+			if Self::is_heartbeat_offence_active() {
 				let validator_set_count = current_validators.len() as u32;
 				let offence = UnresponsivenessOffence {
 					session_index,
@@ -197,7 +192,7 @@ where
 impl<T: Config> Pallet<T> {
 	/// Verifies if the given account is a (candidate) relayer
 	pub fn is_relayer(relayer: &T::AccountId) -> bool {
-		if <RelayerState<T>>::get(relayer).is_some() {
+		if Self::relayer_state(relayer).is_some() {
 			return true;
 		}
 		false
@@ -207,17 +202,15 @@ impl<T: Config> Pallet<T> {
 	/// the beginning of the current round
 	pub fn is_selected_relayer(relayer: &T::AccountId, is_initial: bool) -> bool {
 		if is_initial {
-			<InitialSelectedRelayers<T>>::get().binary_search(relayer).is_ok()
+			Self::initial_selected_relayers().contains(relayer)
 		} else {
-			<SelectedRelayers<T>>::get().binary_search(relayer).is_ok()
+			Self::selected_relayers().contains(relayer)
 		}
 	}
 
 	/// Compute majority based on the current selected relayers
 	fn compute_majority() -> u32 {
-		let selected_relayers = <SelectedRelayers<T>>::get();
-		let half = (selected_relayers.len() as u32) / 2;
-		return half + 1;
+		((Self::selected_relayers().len() as u32) / 2) + 1
 	}
 
 	/// Verifies the existence of the given relayer and controller account. If it is both not bonded
@@ -234,7 +227,7 @@ impl<T: Config> Pallet<T> {
 	/// Sets the liveness of the requested relayer to `true`.
 	pub fn pulse_heartbeat(relayer: &T::AccountId) -> bool {
 		let session_index = T::ValidatorSet::session_index();
-		if !<ReceivedHeartbeats<T>>::get(session_index, relayer) {
+		if !Self::received_heartbeats(session_index, relayer) {
 			<ReceivedHeartbeats<T>>::insert(session_index, relayer, true);
 			return true;
 		}
@@ -245,53 +238,48 @@ impl<T: Config> Pallet<T> {
 	/// `true` if the given relayer sent a heartbeat in the current session.
 	pub fn is_heartbeat_pulsed(relayer: &T::AccountId) -> bool {
 		let session_index = T::ValidatorSet::session_index();
-		<ReceivedHeartbeats<T>>::get(session_index, relayer)
+		Self::received_heartbeats(session_index, relayer)
 	}
 
 	/// Remove the given `relayer` from the `SelectedRelayers`. Returns `true` if the relayer has
 	/// been removed.
 	fn remove_from_selected_relayers(relayer: &T::AccountId) -> bool {
-		let mut selected_relayers = <SelectedRelayers<T>>::get();
-		let prev_len = selected_relayers.len();
-		selected_relayers.retain(|r| r != relayer);
-		let curr_len = selected_relayers.len();
-		<SelectedRelayers<T>>::put(selected_relayers);
-		curr_len < prev_len
+		<SelectedRelayers<T>>::mutate(|selected_relayers| -> bool {
+			selected_relayers.remove(relayer)
+		})
 	}
 
 	/// Add the given `relayer` to the `SelectedRelayers`
-	fn add_to_selected_relayers(relayer: T::AccountId) {
-		let mut selected_relayers = <SelectedRelayers<T>>::get();
-		selected_relayers.try_push(relayer).expect("SelectedRelayers out of bound");
-		selected_relayers.sort();
-		<SelectedRelayers<T>>::put(selected_relayers);
+	fn add_to_selected_relayers(relayer: T::AccountId) -> Result<bool, DispatchError> {
+		<SelectedRelayers<T>>::try_mutate(|selected_relayers| -> Result<bool, DispatchError> {
+			Ok(selected_relayers.try_insert(relayer).map_err(|_| <Error<T>>::TooManyRelayers)?)
+		})
 	}
 
 	/// Refresh the latest rounds cached selected relayers to the current state
 	fn refresh_latest_cached_relayers() {
-		let round = <Round<T>>::get();
-		let selected_relayers = <SelectedRelayers<T>>::get();
-		let mut cached_selected_relayers = <CachedSelectedRelayers<T>>::get();
-		cached_selected_relayers.retain(|r| r.0 != round);
-		cached_selected_relayers.push((round, selected_relayers.into_inner()));
-		<CachedSelectedRelayers<T>>::put(cached_selected_relayers);
+		let round = Self::round();
+		<CachedSelectedRelayers<T>>::mutate(|cached_selected_relayers| {
+			if let Some(relayers) = cached_selected_relayers.get_mut(&round) {
+				*relayers = Self::selected_relayers();
+			}
+		});
 	}
 
 	/// Refresh the latest rounds cached majority to the current state
 	fn refresh_latest_cached_majority() {
-		let round = <Round<T>>::get();
-		let majority = <Majority<T>>::get();
-		let mut cached_majority = <CachedMajority<T>>::get();
-		cached_majority.retain(|r| r.0 != round);
-		cached_majority.push((round, majority));
-		<CachedMajority<T>>::put(cached_majority);
+		let round = Self::round();
+		<CachedMajority<T>>::mutate(|cached_majority| {
+			cached_majority.retain(|r| r.0 != round);
+			cached_majority.push((round, Self::majority()));
+		});
 	}
 
 	/// Remove the given `acc` from the `RelayerPool`. The `is_relayer` parameter represents whether
 	/// the given `acc` references to the relayer account or not. It it's not, it represents the
 	/// bonded controller account. Returns `true` if the relayer has been removed.
 	fn remove_from_relayer_pool(acc: &T::AccountId, is_relayer: bool) -> bool {
-		let mut pool = <RelayerPool<T>>::get();
+		let mut pool = Self::relayer_pool();
 		let prev_len = pool.len();
 		pool.retain(|r| if is_relayer { r.relayer != *acc } else { r.controller != *acc });
 		let curr_len = pool.len();
@@ -300,29 +288,36 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Add the given `relayer` and `controller` pair to the `RelayerPool`
-	fn add_to_relayer_pool(relayer: T::AccountId, controller: T::AccountId) {
-		let mut pool = <RelayerPool<T>>::get();
-		pool.try_push(Relayer { relayer, controller })
-			.expect("RelayerPool out of bound");
-		<RelayerPool<T>>::put(pool);
+	fn add_to_relayer_pool(relayer: T::AccountId, controller: T::AccountId) -> DispatchResult {
+		<RelayerPool<T>>::try_mutate(|pool| -> DispatchResult {
+			Ok(pool
+				.try_push(Relayer { relayer, controller })
+				.map_err(|_| <Error<T>>::TooManyRelayers)?)
+		})
 	}
 
 	/// Replace the `old` account that is used as a storage key for `SelectedRelayers` related
 	/// values to the given `new` account.
-	fn replace_selected_relayers(old: &T::AccountId, new: &T::AccountId) {
+	fn replace_selected_relayers(old: &T::AccountId, new: &T::AccountId) -> DispatchResult {
 		if Self::remove_from_selected_relayers(old) {
-			Self::add_to_selected_relayers(new.clone());
+			Self::add_to_selected_relayers(new.clone())?;
 			Self::refresh_latest_cached_relayers();
 			// replace pulsed heartbeats
 			Self::replace_heartbeats(old, new);
 		}
+		Ok(())
 	}
 
 	/// Replace the `old` relayer account to the `new` relayer account from the `RelayerPool`
-	fn replace_relayer_pool(old: &T::AccountId, new: &T::AccountId, controller: T::AccountId) {
+	fn replace_relayer_pool(
+		old: &T::AccountId,
+		new: &T::AccountId,
+		controller: T::AccountId,
+	) -> DispatchResult {
 		if Self::remove_from_relayer_pool(old, true) {
-			Self::add_to_relayer_pool(new.clone(), controller);
+			Self::add_to_relayer_pool(new.clone(), controller)?;
 		}
+		Ok(())
 	}
 
 	/// Replace the `ReceivedHeartbeats` mapped key from `old` to `new`
@@ -334,7 +329,10 @@ impl<T: Config> Pallet<T> {
 
 	/// Try to replace the bonded `old` relayer account to the given `new` relayer account. Returns
 	/// `true` if the bonded relayer has been replaced.
-	pub fn replace_bonded_relayer(old: &T::AccountId, new: &T::AccountId) -> bool {
+	pub fn replace_bonded_relayer(
+		old: &T::AccountId,
+		new: &T::AccountId,
+	) -> Result<bool, DispatchError> {
 		if let Some(old_state) = <RelayerState<T>>::take(old) {
 			let controller = old_state.clone().controller;
 			// replace bonded controller
@@ -342,11 +340,11 @@ impl<T: Config> Pallet<T> {
 			// replace relayer state
 			<RelayerState<T>>::insert(new, old_state.clone());
 			// replace relayer pool
-			Self::replace_relayer_pool(&old, &new, controller.clone());
+			Self::replace_relayer_pool(&old, &new, controller.clone())?;
 			// replace selected relayers
-			Self::replace_selected_relayers(&old, &new);
-			return true;
+			Self::replace_selected_relayers(&old, &new)?;
+			return Ok(true);
 		}
-		return false;
+		return Ok(false);
 	}
 }

--- a/pallets/relay-manager/src/pallet/impls.rs
+++ b/pallets/relay-manager/src/pallet/impls.rs
@@ -270,10 +270,8 @@ impl<T: Config> Pallet<T> {
 	fn refresh_latest_cached_majority() {
 		let round = Self::round();
 		<CachedMajority<T>>::mutate(|cached_majority| {
-			cached_majority
-				.entry(round)
-				.and_modify(|majority| *majority = Self::majority())
-				.or_insert(Self::majority());
+			let majority = Self::majority();
+			cached_majority.entry(round).and_modify(|m| *m = majority).or_insert(majority);
 		});
 	}
 

--- a/pallets/relay-manager/src/pallet/impls.rs
+++ b/pallets/relay-manager/src/pallet/impls.rs
@@ -260,9 +260,11 @@ impl<T: Config> Pallet<T> {
 	fn refresh_latest_cached_relayers() {
 		let round = Self::round();
 		<CachedSelectedRelayers<T>>::mutate(|cached_selected_relayers| {
-			if let Some(relayers) = cached_selected_relayers.get_mut(&round) {
-				*relayers = Self::selected_relayers();
-			}
+			let selected_relayers = Self::selected_relayers();
+			cached_selected_relayers
+				.entry(round)
+				.and_modify(|s| *s = selected_relayers.clone())
+				.or_insert(selected_relayers);
 		});
 	}
 

--- a/pallets/relay-manager/src/pallet/impls.rs
+++ b/pallets/relay-manager/src/pallet/impls.rs
@@ -20,7 +20,7 @@ where
 	>,
 {
 	fn join_relayers(relayer: T::AccountId, controller: T::AccountId) -> Result<(), DispatchError> {
-		Self::verify_relayer_existance(&relayer, &controller)?;
+		Self::verify_relayer_existence(&relayer, &controller)?;
 		Self::add_to_relayer_pool(relayer.clone(), controller.clone());
 		<RelayerState<T>>::insert(&relayer, RelayerMetadata::new(controller.clone()));
 		<BondedController<T>>::insert(&controller, relayer.clone());
@@ -220,9 +220,9 @@ impl<T: Config> Pallet<T> {
 		return half + 1;
 	}
 
-	/// Verifies the existance of the given relayer and controller account. If it is both not bonded
+	/// Verifies the existence of the given relayer and controller account. If it is both not bonded
 	/// yet, it will return an `Ok`, if not an `Error` will be returned.
-	fn verify_relayer_existance(
+	fn verify_relayer_existence(
 		relayer: &T::AccountId,
 		controller: &T::AccountId,
 	) -> Result<(), DispatchError> {

--- a/pallets/relay-manager/src/pallet/mod.rs
+++ b/pallets/relay-manager/src/pallet/mod.rs
@@ -202,7 +202,7 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		fn on_runtime_upgrade() -> Weight {
 			migrations::v4::MigrateToV4::<T>::on_runtime_upgrade()
 		}
 	}
@@ -235,7 +235,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: u32,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(new >= 1u32, Error::<T>::CannotSetBelowOne);
 			let old = <StorageCacheLifetime<T>>::get();
 			ensure!(old != new, Error::<T>::NoWritingSameValue);
@@ -251,7 +251,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			is_active: bool,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			ensure!(
 				is_active != <IsHeartbeatOffenceActive<T>>::get(),
 				Error::<T>::NoWritingSameValue
@@ -268,7 +268,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: Perbill,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			ensure_root(origin)?;
 			let old = <HeartbeatSlashFraction<T>>::get();
 			ensure!(old != new, Error::<T>::NoWritingSameValue);
 			<HeartbeatSlashFraction<T>>::put(new);

--- a/pallets/relay-manager/src/pallet/mod.rs
+++ b/pallets/relay-manager/src/pallet/mod.rs
@@ -179,14 +179,14 @@ pub mod pallet {
 	#[pallet::unbounded]
 	#[pallet::getter(fn cached_majority)]
 	/// The cached majority based on the active relayer set selected from previous rounds
-	pub type CachedMajority<T: Config> = StorageValue<_, Vec<(RoundIndex, u32)>, ValueQuery>;
+	pub type CachedMajority<T: Config> = StorageValue<_, BTreeMap<RoundIndex, u32>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::unbounded]
 	#[pallet::getter(fn cached_initial_majority)]
 	/// The cached majority based on the active relayer set selected from the beginning of each
 	/// previous rounds
-	pub type CachedInitialMajority<T: Config> = StorageValue<_, Vec<(RoundIndex, u32)>, ValueQuery>;
+	pub type CachedInitialMajority<T: Config> = StorageValue<_, BTreeMap<RoundIndex, u32>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn received_heartbeats)]

--- a/precompiles/bfc-offences/src/lib.rs
+++ b/precompiles/bfc-offences/src/lib.rs
@@ -67,11 +67,9 @@ where
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
 		if let Some(offence) = OffencesOf::<Runtime>::validator_offences(&validator) {
-			let mut new = ValidatorOffence::<Runtime>::default();
-			new.set_offence(validator, offence);
-			Ok(new.into())
+			Ok(ValidatorOffence::<Runtime>::set_offence(validator, offence).into())
 		} else {
-			Ok(ValidatorOffence::<Runtime>::default().into())
+			Ok(ValidatorOffence::<Runtime>::set_empty(validator).into())
 		}
 	}
 
@@ -95,9 +93,8 @@ where
 		let mut validator_offences = ValidatorOffences::<Runtime>::default();
 		unique_validators.clone().into_iter().for_each(|v| {
 			if let Some(offence) = OffencesOf::<Runtime>::validator_offences(&v) {
-				let mut new = ValidatorOffence::<Runtime>::default();
-				new.set_offence(v, offence);
-				validator_offences.insert_offence(new);
+				validator_offences
+					.insert_offence(ValidatorOffence::<Runtime>::set_offence(v, offence));
 			} else {
 				validator_offences.insert_empty(v);
 			}

--- a/precompiles/bfc-offences/src/types.rs
+++ b/precompiles/bfc-offences/src/types.rs
@@ -48,15 +48,23 @@ where
 		}
 	}
 
+	pub fn set_empty(validator: Runtime::AccountId) -> Self {
+		let mut offence = Self::default();
+		offence.validator = Address(validator.into());
+		offence
+	}
+
 	pub fn set_offence(
-		&mut self,
 		validator: Runtime::AccountId,
 		offence: ValidatorOffenceInfo<BalanceOf<Runtime>>,
-	) {
-		self.validator = Address(validator.into());
-		self.latest_offence_round_index = offence.latest_offence_round_index;
-		self.latest_offence_session_index = offence.latest_offence_session_index;
-		self.offence_count = offence.offence_count;
+	) -> Self {
+		Self {
+			validator: Address(validator.into()),
+			latest_offence_round_index: offence.latest_offence_round_index,
+			latest_offence_session_index: offence.latest_offence_session_index,
+			offence_count: offence.offence_count,
+			phantom: PhantomData,
+		}
 	}
 }
 

--- a/precompiles/bfc-offences/src/types.rs
+++ b/precompiles/bfc-offences/src/types.rs
@@ -60,6 +60,20 @@ where
 	}
 }
 
+impl<Runtime> From<ValidatorOffence<Runtime>> for EvmValidatorOffenceOf
+where
+	Runtime: pallet_bfc_offences::Config,
+{
+	fn from(offence: ValidatorOffence<Runtime>) -> Self {
+		(
+			offence.validator,
+			offence.latest_offence_round_index,
+			offence.latest_offence_session_index,
+			offence.offence_count,
+		)
+	}
+}
+
 /// EVM struct for validator offences
 pub struct ValidatorOffences<Runtime: pallet_bfc_offences::Config> {
 	/// The address of this validator
@@ -101,20 +115,6 @@ where
 		self.latest_offence_round_index.push(offence.latest_offence_round_index);
 		self.latest_offence_session_index.push(offence.latest_offence_session_index);
 		self.offence_count.push(offence.offence_count);
-	}
-}
-
-impl<Runtime> From<ValidatorOffences<Runtime>> for EvmValidatorOffenceOf
-where
-	Runtime: pallet_bfc_offences::Config,
-{
-	fn from(offence: ValidatorOffences<Runtime>) -> Self {
-		(
-			offence.validator[0],
-			offence.latest_offence_round_index[0],
-			offence.latest_offence_session_index[0],
-			offence.offence_count[0],
-		)
 	}
 }
 

--- a/precompiles/bfc-staking/src/lib.rs
+++ b/precompiles/bfc-staking/src/lib.rs
@@ -756,7 +756,7 @@ where
 	fn candidate_pool(handle: &mut impl PrecompileHandle) -> EvmResult<EvmCandidatePoolOf> {
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
-		let candidate_pool = <StakingOf<Runtime>>::candidate_pool();
+		let candidate_pool = <StakingOf<Runtime>>::get_sorted_candidates();
 
 		let mut candidates: Vec<Address> = vec![];
 		let mut bonds: Vec<U256> = vec![];

--- a/precompiles/bfc-staking/src/lib.rs
+++ b/precompiles/bfc-staking/src/lib.rs
@@ -1075,7 +1075,7 @@ where
 
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 		let result = if let Some(state) = <StakingOf<Runtime>>::nominator_state(&nominator) {
-			let nominator_nomination_count: u32 = state.nominations.0.len() as u32;
+			let nominator_nomination_count: u32 = state.nominations.len() as u32;
 			nominator_nomination_count
 		} else {
 			0u32

--- a/precompiles/bfc-staking/src/lib.rs
+++ b/precompiles/bfc-staking/src/lib.rs
@@ -109,18 +109,6 @@ where
 		Ok(is_selected_candidate)
 	}
 
-	fn get_unique_candidates(candidates: &Vec<Address>) -> EvmResult<BTreeSet<Runtime::AccountId>> {
-		let unique_candidates: BTreeSet<Runtime::AccountId> = candidates
-			.iter()
-			.map(|address| Runtime::AddressMapping::into_account_id(address.0))
-			.collect();
-		if unique_candidates.len() != candidates.len() {
-			return Err(RevertReason::custom("Duplicate candidate address received").into());
-		}
-
-		Ok(unique_candidates)
-	}
-
 	/// Verifies if each of the address in the given `candidates` vector parameter
 	/// is a active validator for the current round
 	/// @param: `candidates` the address vector for which to verify
@@ -169,17 +157,6 @@ where
 			},
 			true,
 		))
-	}
-
-	fn get_previous_selected_candidates(
-		round_index: &RoundIndex,
-	) -> EvmResult<BoundedBTreeSet<Runtime::AccountId, ConstU32<MAX_AUTHORITIES>>> {
-		let previous_selected_candidates = <StakingOf<Runtime>>::cached_selected_candidates();
-		if let Some(previous_selected_candidates) = previous_selected_candidates.get(round_index) {
-			Ok(previous_selected_candidates.clone())
-		} else {
-			Err(RevertReason::read_out_of_bounds("round_index").into())
-		}
 	}
 
 	/// Verifies if the given `candidate` parameter was an active validator at the given
@@ -1350,6 +1327,29 @@ where
 	}
 
 	// Util methods
+
+	fn get_unique_candidates(candidates: &Vec<Address>) -> EvmResult<BTreeSet<Runtime::AccountId>> {
+		let unique_candidates: BTreeSet<Runtime::AccountId> = candidates
+			.iter()
+			.map(|address| Runtime::AddressMapping::into_account_id(address.0))
+			.collect();
+		if unique_candidates.len() != candidates.len() {
+			return Err(RevertReason::custom("Duplicate candidate address received").into());
+		}
+
+		Ok(unique_candidates)
+	}
+
+	fn get_previous_selected_candidates(
+		round_index: &RoundIndex,
+	) -> EvmResult<BoundedBTreeSet<Runtime::AccountId, ConstU32<MAX_AUTHORITIES>>> {
+		let previous_selected_candidates = <StakingOf<Runtime>>::cached_selected_candidates();
+		if let Some(previous_selected_candidates) = previous_selected_candidates.get(round_index) {
+			Ok(previous_selected_candidates.clone())
+		} else {
+			Err(RevertReason::read_out_of_bounds("round_index").into())
+		}
+	}
 
 	fn compare_selected_candidates(
 		candidates: BTreeSet<Runtime::AccountId>,

--- a/precompiles/bfc-staking/src/types.rs
+++ b/precompiles/bfc-staking/src/types.rs
@@ -483,13 +483,13 @@ where
 	}
 
 	pub fn set_state(&mut self, state: Nominator<Runtime::AccountId, BalanceOf<Runtime>>) {
-		state.nominations.iter().for_each(|(owner, amount)| {
-			self.candidates.push(Address(owner.clone().into()));
-			self.nominations.push(*amount);
+		state.nominations.into_iter().for_each(|(owner, amount)| {
+			self.candidates.push(Address(owner.into()));
+			self.nominations.push(amount);
 		});
-		for nomination in state.initial_nominations {
-			self.initial_nominations.push(nomination.amount);
-		}
+		state.initial_nominations.into_iter().for_each(|(_, amount)| {
+			self.initial_nominations.push(amount);
+		});
 
 		self.total = state.total;
 		self.request_revocations_count = state.requests.revocations_count.into();

--- a/precompiles/bfc-staking/src/types.rs
+++ b/precompiles/bfc-staking/src/types.rs
@@ -483,11 +483,11 @@ where
 	}
 
 	pub fn set_state(&mut self, state: Nominator<Runtime::AccountId, BalanceOf<Runtime>>) {
-		for nomination in state.nominations.0 {
-			self.candidates.push(Address(nomination.owner.into()));
-			self.nominations.push(nomination.amount);
-		}
-		for nomination in state.initial_nominations.0 {
+		state.nominations.iter().for_each(|(owner, amount)| {
+			self.candidates.push(Address(owner.clone().into()));
+			self.nominations.push(*amount);
+		});
+		for nomination in state.initial_nominations {
 			self.initial_nominations.push(nomination.amount);
 		}
 
@@ -505,9 +505,10 @@ where
 			RewardDestination::Account => 1u32.into(),
 		};
 
-		for awarded_token in state.awarded_tokens_per_candidate.0 {
-			self.awarded_tokens_per_candidate.push(awarded_token.amount);
-		}
+		state.awarded_tokens_per_candidate.iter().for_each(|(_, amount)| {
+			self.awarded_tokens_per_candidate.push(*amount);
+		});
+
 		self.awarded_tokens = state.awarded_tokens;
 	}
 

--- a/precompiles/relay-manager/src/lib.rs
+++ b/precompiles/relay-manager/src/lib.rs
@@ -1,15 +1,17 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
+use frame_support::pallet_prelude::ConstU32;
+use frame_support::BoundedBTreeSet;
 
 use pallet_evm::AddressMapping;
 use pallet_relay_manager::Call as RelayManagerCall;
 
 use precompile_utils::prelude::*;
 
-use bp_staking::RoundIndex;
+use bp_staking::{RoundIndex, MAX_AUTHORITIES};
 use sp_core::{H160, H256, U256};
-use sp_std::{marker::PhantomData, vec, vec::Vec};
+use sp_std::{collections::btree_set::BTreeSet, marker::PhantomData, vec, vec::Vec};
 
 mod types;
 use types::{EvmRelayerStateOf, EvmRelayerStatesOf, RelayManagerOf, RelayerState, RelayerStates};
@@ -161,6 +163,23 @@ where
 		Ok(is_relayers)
 	}
 
+	fn get_previous_selected_relayers(
+		round_index: &RoundIndex,
+		is_initial: bool,
+	) -> EvmResult<BoundedBTreeSet<Runtime::AccountId, ConstU32<MAX_AUTHORITIES>>> {
+		let previous_selected_relayers = if is_initial {
+			RelayManagerOf::<Runtime>::cached_initial_selected_relayers()
+		} else {
+			RelayManagerOf::<Runtime>::cached_selected_relayers()
+		};
+
+		if let Some(previous_selected_relayers) = previous_selected_relayers.get(round_index) {
+			return Ok(previous_selected_relayers.clone());
+		} else {
+			Err(RevertReason::read_out_of_bounds("round_index").into())
+		}
+	}
+
 	#[precompile::public("isPreviousSelectedRelayer(uint256,address,bool)")]
 	#[precompile::public("is_previous_selected_relayer(uint256,address,bool)")]
 	#[precompile::view]
@@ -173,35 +192,8 @@ where
 		let relayer = Runtime::AddressMapping::into_account_id(relayer.0);
 
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-		let mut result: bool = false;
-		let previous_selected_relayers = match is_initial {
-			true => RelayManagerOf::<Runtime>::cached_initial_selected_relayers(),
-			false => RelayManagerOf::<Runtime>::cached_selected_relayers(),
-		};
 
-		let cached_len = previous_selected_relayers.len();
-		if cached_len > 0 {
-			let head_selected = &previous_selected_relayers[0];
-			let tail_selected = &previous_selected_relayers[cached_len - 1];
-
-			// out of round index
-			if round_index < head_selected.0 || round_index > tail_selected.0 {
-				return Err(RevertReason::read_out_of_bounds("round_index").into());
-			}
-			'outer: for selected_relayers in previous_selected_relayers {
-				if round_index == selected_relayers.0 {
-					for selected_relayer in selected_relayers.1 {
-						if relayer == selected_relayer {
-							result = true;
-							break 'outer;
-						}
-					}
-					break;
-				}
-			}
-		}
-
-		Ok(result)
+		Ok(Self::get_previous_selected_relayers(&round_index, is_initial)?.contains(&relayer))
 	}
 
 	#[precompile::public("isPreviousSelectedRelayers(uint256,address[],bool)")]
@@ -214,55 +206,25 @@ where
 		is_initial: bool,
 	) -> EvmResult<bool> {
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-		let mut unique_relayers = relayers
-			.clone()
-			.into_iter()
-			.map(|address| Runtime::AddressMapping::into_account_id(address.0))
-			.collect::<Vec<Runtime::AccountId>>();
 
-		let previous_len = unique_relayers.len();
-		unique_relayers.sort();
-		unique_relayers.dedup();
-		let current_len = unique_relayers.len();
-		if current_len < previous_len {
+		let unique_relayers = relayers
+			.iter()
+			.map(|address| Runtime::AddressMapping::into_account_id(address.0))
+			.collect::<BTreeSet<Runtime::AccountId>>();
+		if unique_relayers.len() != relayers.len() {
 			return Err(RevertReason::custom("Duplicate candidate address received").into());
 		}
 
-		let mut result: bool = false;
-		if unique_relayers.len() > 0 {
-			let previous_selected_relayers = match is_initial {
-				true => RelayManagerOf::<Runtime>::cached_initial_selected_relayers(),
-				false => RelayManagerOf::<Runtime>::cached_selected_relayers(),
-			};
-
-			let cached_len = previous_selected_relayers.len();
-			if cached_len > 0 {
-				let head_selected = &previous_selected_relayers[0];
-				let tail_selected = &previous_selected_relayers[cached_len - 1];
-
-				if round_index < head_selected.0 || round_index > tail_selected.0 {
-					return Err(RevertReason::read_out_of_bounds("round_index").into());
-				}
-				'outer: for selected_relayers in previous_selected_relayers {
-					if round_index == selected_relayers.0 {
-						let mutated_relayers: Vec<Address> = selected_relayers
-							.1
-							.into_iter()
-							.map(|address| Address(address.into()))
-							.collect();
-						for relayer in relayers {
-							if !mutated_relayers.contains(&relayer) {
-								break 'outer;
-							}
-						}
-						result = true;
-						break;
-					}
-				}
-			}
+		let previous_selected_relayers =
+			Self::get_previous_selected_relayers(&round_index, is_initial)?;
+		if previous_selected_relayers.is_empty() {
+			return Ok(false);
 		}
 
-		Ok(result)
+		Ok(relayers.iter().all(|relayer| {
+			previous_selected_relayers
+				.contains(&Runtime::AddressMapping::into_account_id(relayer.0))
+		}))
 	}
 
 	#[precompile::public("isHeartbeatPulsed(address)")]
@@ -312,31 +274,14 @@ where
 		is_initial: bool,
 	) -> EvmResult<Vec<Address>> {
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-		let previous_selected_relayers = match is_initial {
-			true => RelayManagerOf::<Runtime>::cached_initial_selected_relayers(),
-			false => RelayManagerOf::<Runtime>::cached_selected_relayers(),
-		};
 
-		let mut result: Vec<Address> = vec![];
-		let cached_len = previous_selected_relayers.len();
-		if cached_len > 0 {
-			let head_selected = &previous_selected_relayers[0];
-			let tail_selected = &previous_selected_relayers[cached_len - 1];
+		let previous_selected_relayers =
+			Self::get_previous_selected_relayers(&round_index, is_initial)?;
 
-			// out of round index
-			if round_index < head_selected.0 || round_index > tail_selected.0 {
-				return Err(RevertReason::read_out_of_bounds("round_index").into());
-			}
-			for relayers in previous_selected_relayers {
-				if round_index == relayers.0 {
-					result =
-						relayers.1.into_iter().map(|address| Address(address.into())).collect();
-					break;
-				}
-			}
-		}
-
-		Ok(result)
+		Ok(previous_selected_relayers
+			.into_iter()
+			.map(|account_id| Address(account_id.into()))
+			.collect())
 	}
 
 	#[precompile::public("relayerPool()")]

--- a/precompiles/relay-manager/src/lib.rs
+++ b/precompiles/relay-manager/src/lib.rs
@@ -172,7 +172,7 @@ where
 			.map(|address| Runtime::AddressMapping::into_account_id(address.0))
 			.collect::<BTreeSet<Runtime::AccountId>>();
 		if unique_relayers.len() != relayers.len() {
-			return Err(RevertReason::custom("Duplicate candidate address received").into());
+			return Err(RevertReason::custom("Duplicate relayer address received").into());
 		}
 
 		let previous_selected_relayers =

--- a/precompiles/relay-manager/src/types.rs
+++ b/precompiles/relay-manager/src/types.rs
@@ -52,6 +52,15 @@ where
 	}
 }
 
+impl<Runtime> From<RelayerState<Runtime>> for EvmRelayerStateOf
+where
+	Runtime: pallet_relay_manager::Config,
+{
+	fn from(state: RelayerState<Runtime>) -> Self {
+		(state.relayer, state.controller, state.status)
+	}
+}
+
 /// EVM struct for relayer states
 pub struct RelayerStates<Runtime: pallet_relay_manager::Config> {
 	/// This relayer's account
@@ -83,15 +92,6 @@ where
 		self.relayer.push(Address(state.relayer.into()));
 		self.controller.push(Address(state.controller.into()));
 		self.status.push(state.status);
-	}
-}
-
-impl<Runtime> From<RelayerStates<Runtime>> for EvmRelayerStateOf
-where
-	Runtime: pallet_relay_manager::Config,
-{
-	fn from(state: RelayerStates<Runtime>) -> Self {
-		(state.relayer[0], state.controller[0], state.status[0])
 	}
 }
 

--- a/primitives/bfc-staking/src/traits.rs
+++ b/primitives/bfc-staking/src/traits.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use crate::{Offence, RoundIndex, TierType};
+use crate::{Offence, RoundIndex, TierType, MAX_AUTHORITIES};
+use frame_support::{pallet_prelude::ConstU32, BoundedBTreeSet};
 
 use sp_runtime::{DispatchError, Perbill};
 use sp_std::vec::Vec;
@@ -17,7 +18,10 @@ pub trait RelayManager<AccountId> {
 	fn refresh_selected_relayers(round: RoundIndex, selected_candidates: Vec<AccountId>);
 
 	/// Refresh the `CachedSelectedRelayers` based on the new selected relayers
-	fn refresh_cached_selected_relayers(round: RoundIndex, relayers: Vec<AccountId>);
+	fn refresh_cached_selected_relayers(
+		round: RoundIndex,
+		relayers: BoundedBTreeSet<AccountId, ConstU32<MAX_AUTHORITIES>>,
+	);
 
 	/// Refresh the `Majority` and `CachedMajority` of the selected relayers
 	fn refresh_majority(round: RoundIndex);

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -140,7 +140,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 305,
+	spec_version: 306,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -713,8 +713,6 @@ parameter_types! {
 	pub const DefaultMaxSelectedFullCandidates: u32 = 10;
 	/// Default maximum basicvalidators selected per round, default at genesis.
 	pub const DefaultMaxSelectedBasicCandidates: u32 = 10;
-	/// Default minimum validators selected per round, default at genesis.
-	pub const DefaultMinSelectedCandidates: u32 = 1;
 	/// Maximum top nominations per candidate.
 	pub const MaxTopNominationsPerCandidate: u32 = 10;
 	/// Maximum bottom nominations per candidate.
@@ -760,7 +758,6 @@ impl pallet_bfc_staking::Config for Runtime {
 	type RewardPaymentDelay = RewardPaymentDelay;
 	type DefaultMaxSelectedFullCandidates = DefaultMaxSelectedFullCandidates;
 	type DefaultMaxSelectedBasicCandidates = DefaultMaxSelectedBasicCandidates;
-	type DefaultMinSelectedCandidates = DefaultMinSelectedCandidates;
 	type MaxTopNominationsPerCandidate = MaxTopNominationsPerCandidate;
 	type MaxBottomNominationsPerCandidate = MaxBottomNominationsPerCandidate;
 	type MaxNominationsPerNominator = MaxNominationsPerNominator;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -713,8 +713,6 @@ parameter_types! {
 	pub const DefaultMaxSelectedFullCandidates: u32 = 20;
 	/// Default maximum basic validators selected per round, default at genesis.
 	pub const DefaultMaxSelectedBasicCandidates: u32 = 200;
-	/// Default minimum validators selected per round, default at genesis.
-	pub const DefaultMinSelectedCandidates: u32 = 1;
 	/// Maximum top nominations per candidate.
 	pub const MaxTopNominationsPerCandidate: u32 = 100;
 	/// Maximum bottom nominations per candidate.
@@ -760,7 +758,6 @@ impl pallet_bfc_staking::Config for Runtime {
 	type RewardPaymentDelay = RewardPaymentDelay;
 	type DefaultMaxSelectedFullCandidates = DefaultMaxSelectedFullCandidates;
 	type DefaultMaxSelectedBasicCandidates = DefaultMaxSelectedBasicCandidates;
-	type DefaultMinSelectedCandidates = DefaultMinSelectedCandidates;
 	type MaxTopNominationsPerCandidate = MaxTopNominationsPerCandidate;
 	type MaxBottomNominationsPerCandidate = MaxBottomNominationsPerCandidate;
 	type MaxNominationsPerNominator = MaxNominationsPerNominator;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -719,8 +719,6 @@ parameter_types! {
 	pub const DefaultMaxSelectedFullCandidates: u32 = 30;
 	/// Default maximum basic validators selected per round, default at genesis.
 	pub const DefaultMaxSelectedBasicCandidates: u32 = 170;
-	/// Default minimum validators selected per round, default at genesis.
-	pub const DefaultMinSelectedCandidates: u32 = 1;
 	/// Maximum top nominations per candidate.
 	pub const MaxTopNominationsPerCandidate: u32 = 100;
 	/// Maximum bottom nominations per candidate.
@@ -766,7 +764,6 @@ impl pallet_bfc_staking::Config for Runtime {
 	type RewardPaymentDelay = RewardPaymentDelay;
 	type DefaultMaxSelectedFullCandidates = DefaultMaxSelectedFullCandidates;
 	type DefaultMaxSelectedBasicCandidates = DefaultMaxSelectedBasicCandidates;
-	type DefaultMinSelectedCandidates = DefaultMinSelectedCandidates;
 	type MaxTopNominationsPerCandidate = MaxTopNominationsPerCandidate;
 	type MaxBottomNominationsPerCandidate = MaxBottomNominationsPerCandidate;
 	type MaxNominationsPerNominator = MaxNominationsPerNominator;

--- a/tests/tests/pallets/test_bfc_offences.ts
+++ b/tests/tests/pallets/test_bfc_offences.ts
@@ -217,8 +217,8 @@ describeDevNode('pallet_bfc_offences - simple validator offences', (context) => 
     const candidateState = rawCandidateState.unwrap().toJSON();
     const selfBondBeforeSlash = candidateState.bond;
 
-    const rawTreauryId: any = await context.polkadotApi.query.treasury.treasuryId();
-    const treasuryId = rawTreauryId.toJSON();
+    const rawTreasuryId: any = await context.polkadotApi.query.treasury.treasuryId();
+    const treasuryId = rawTreasuryId.toJSON();
     const potBalanceBefore = new BigNumber((await context.web3.eth.getBalance(treasuryId)).toString());
 
     let offenceLength = 1;
@@ -252,11 +252,8 @@ describeDevNode('pallet_bfc_offences - simple validator offences', (context) => 
         const rawCandidatePool: any = await context.polkadotApi.query.bfcStaking.candidatePool();
         const candidatePool = rawCandidatePool.toJSON();
         let isCandidateFound = false;
-        for (const candidate of candidatePool) {
-          if (candidate.owner === baltathar.address) {
-            isCandidateFound = true;
-            break;
-          }
+        if (candidatePool[baltathar.address]) {
+          isCandidateFound = true;
         }
         expect(isCandidateFound).equal(false);
 
@@ -276,15 +273,8 @@ describeDevNode('pallet_bfc_offences - simple validator offences', (context) => 
         const rawCachedSelectedCandidates: any = await context.polkadotApi.query.bfcStaking.cachedSelectedCandidates();
         const cachedSelectedCandidates = rawCachedSelectedCandidates.toJSON();
         let isCachedCandidate = false;
-        for (const cache of cachedSelectedCandidates) {
-          if (cache[0] === currentRound) {
-            for (const candidate of cache[1]) {
-              if (candidate === baltathar.address) {
-                isCachedCandidate = true;
-                break;
-              }
-            }
-          }
+        if (cachedSelectedCandidates[currentRound].includes(baltathar.address)) {
+          isCachedCandidate = true;
         }
         expect(isCachedCandidate).equal(false);
 
@@ -296,8 +286,8 @@ describeDevNode('pallet_bfc_offences - simple validator offences', (context) => 
         expect(new BigNumber(candidateState.votingPower).eq(new BigNumber(selfBondAfterSlash))).equal(true);
 
         // check treasury pot
-        const rawTreauryId: any = await context.polkadotApi.query.treasury.treasuryId();
-        const treasuryId = rawTreauryId.toJSON();
+        const rawTreasuryId: any = await context.polkadotApi.query.treasury.treasuryId();
+        const treasuryId = rawTreasuryId.toJSON();
         const potBalance = new BigNumber((await context.web3.eth.getBalance(treasuryId)).toString());
         expect(potBalance.toFixed()).equal(new BigNumber(25).multipliedBy(10 ** 18).plus(potBalanceBefore).toFixed());
 
@@ -395,11 +385,8 @@ describeDevNode('pallet_bfc_offences - simple validator offences', (context) => 
     const rawCandidatePool: any = await context.polkadotApi.query.bfcStaking.candidatePool();
     const candidatePool = rawCandidatePool.toJSON();
     let isCandidateFound = false;
-    for (const candidate of candidatePool) {
-      if (candidate.owner === baltathar.address) {
-        isCandidateFound = true;
-        break;
-      }
+    if (candidatePool[baltathar.address]) {
+      isCandidateFound = true;
     }
     expect(isCandidateFound).equal(true);
   });
@@ -419,11 +406,8 @@ describeDevNode('pallet_bfc_offences - simple validator offences', (context) => 
     const rawCandidatePool: any = await context.polkadotApi.query.bfcStaking.candidatePool();
     const candidatePool = rawCandidatePool.toJSON();
     let isCandidateFound = false;
-    for (const candidate of candidatePool) {
-      if (candidate.owner === alith.address) {
-        isCandidateFound = true;
-        break;
-      }
+    if (candidatePool[alith.address]) {
+      isCandidateFound = true;
     }
     expect(isCandidateFound).equal(false);
 
@@ -585,11 +569,8 @@ describeDevNode('pallet_bfc_offences - update bond less pending request #1', (co
         const rawCandidatePool: any = await context.polkadotApi.query.bfcStaking.candidatePool();
         const candidatePool = rawCandidatePool.toJSON();
         let isCandidateFound = false;
-        for (const candidate of candidatePool) {
-          if (candidate.owner === baltathar.address) {
-            isCandidateFound = true;
-            break;
-          }
+        if (candidatePool[baltathar.address]) {
+          isCandidateFound = true;
         }
         expect(isCandidateFound).equal(false);
 
@@ -609,15 +590,8 @@ describeDevNode('pallet_bfc_offences - update bond less pending request #1', (co
         const rawCachedSelectedCandidates: any = await context.polkadotApi.query.bfcStaking.cachedSelectedCandidates();
         const cachedSelectedCandidates = rawCachedSelectedCandidates.toJSON();
         let isCachedCandidate = false;
-        for (const cache of cachedSelectedCandidates) {
-          if (cache[0] === currentRound) {
-            for (const candidate of cache[1]) {
-              if (candidate === baltathar.address) {
-                isCachedCandidate = true;
-                break;
-              }
-            }
-          }
+        if (cachedSelectedCandidates[currentRound].includes(baltathar.address)) {
+          isCachedCandidate = true;
         }
         expect(isCachedCandidate).equal(false);
 

--- a/tests/tests/pallets/test_relay_manager.ts
+++ b/tests/tests/pallets/test_relay_manager.ts
@@ -56,17 +56,19 @@ describeDevNode('pallet_relay_manager - set relayer', (context) => {
     expect(initialRelayers.length).equal(1);
     expect(initialRelayers[0]).equal(alithRelayer.address);
 
+    const rawCurrentRound: any = await context.polkadotApi.query.bfcStaking.round();
+    const currentRound = rawCurrentRound.currentRoundIndex.toNumber();
+
     // check `CachedSelectedRelayers`
     const rawCachedRelayers: any = await context.polkadotApi.query.relayManager.cachedSelectedRelayers();
     const cachedRelayers = rawCachedRelayers.toJSON();
-    expect(cachedRelayers[0][1].length).equal(1);
-    expect(cachedRelayers[0][1]).include(alithRelayer.address);
+    expect(cachedRelayers[currentRound]).includes(alithRelayer.address);
 
     // check `CachedInitialSelectedRelayers`
     const rawCachedInitialRelayers: any = await context.polkadotApi.query.relayManager.cachedInitialSelectedRelayers();
     const cachedInitialRelayers = rawCachedInitialRelayers.toJSON();
-    expect(cachedInitialRelayers[0][1].length).equal(1);
-    expect(cachedInitialRelayers[0][1]).include(alithRelayer.address);
+    // expect(cachedInitialRelayers[0][1].length).equal(1);
+    expect(cachedInitialRelayers[currentRound]).includes(alithRelayer.address);
   });
 
   before('should successfully send a heartbeat', async function () {
@@ -127,20 +129,22 @@ describeDevNode('pallet_relay_manager - set relayer', (context) => {
     expect(initialRelayers.length).equal(1);
     expect(initialRelayers[0]).equal(alithRelayer.address);
 
+    const rawCurrentRound: any = await context.polkadotApi.query.bfcStaking.round();
+    const currentRound = rawCurrentRound.currentRoundIndex.toNumber();
+
     // check `CachedSelectedRelayers`
     const rawCachedRelayers: any = await context.polkadotApi.query.relayManager.cachedSelectedRelayers();
     const cachedRelayers = rawCachedRelayers.toJSON();
-    expect(cachedRelayers[0][1].length).equal(1);
-    expect(cachedRelayers[0][1]).include(newRelayer.address);
+    expect(cachedRelayers[currentRound].length).equal(1);
+    expect(cachedRelayers[currentRound]).include(newRelayer.address);
 
     // check `CachedInitialSelectedRelayers`
     const rawCachedInitialRelayers: any = await context.polkadotApi.query.relayManager.cachedInitialSelectedRelayers();
     const cachedInitialRelayers = rawCachedInitialRelayers.toJSON();
-    expect(cachedInitialRelayers[0][1].length).equal(1);
-    expect(cachedInitialRelayers[0][1]).include(alithRelayer.address);
+    expect(cachedInitialRelayers[currentRound].length).equal(1);
+    expect(cachedInitialRelayers[currentRound]).include(alithRelayer.address);
 
     // check `ReceivedHeartbeats`
-    const rawCurrentRound: any = await context.polkadotApi.query.bfcStaking.round();
     const currentSession = rawCurrentRound.currentSessionIndex.toNumber();
     const rawHeartbeat: any = await context.polkadotApi.query.relayManager.receivedHeartbeats(currentSession, newRelayer.address);
     const heartbeat = rawHeartbeat.toJSON();

--- a/tests/tests/precompiles/test_bfc_offences.ts
+++ b/tests/tests/precompiles/test_bfc_offences.ts
@@ -15,7 +15,7 @@ const PRECOMPILE_ADDRESS = '0x0000000000000000000000000000000000000500';
 describeDevNode('precompile_bfc_offences - precompile view functions', (context) => {
   const alith: { public: string, private: string } = TEST_CONTROLLERS[0];
 
-  it('should successfully verify offence storage existance', async function () {
+  it('should successfully verify offence storage existence', async function () {
     const maximum_offence_count = await callPrecompile(
       context,
       alith.public,


### PR DESCRIPTION
## Description

* Overall, better expressions applied to the parts that could be used
* Replace `OrderedSet` with `BTreeMap` & `BTreeSet`
* Remove unnecessary `clone()`s. or partially clone.
* Remove redundant codes
* Remove dead code
* Migrate to new standard storage version
* Remove possibly panic points as much as possible
* Remove unnecessary path prefixes
* Fix wrong revert message in precompiles

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
