### PR TITLE
NODE-114, fix: use dynamic multiSig fields & allow duplicate refund addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6228,6 +6228,7 @@ dependencies = [
  "bp-multi-sig",
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/pallets/btc-registration-pool/Cargo.toml
+++ b/pallets/btc-registration-pool/Cargo.toml
@@ -10,6 +10,7 @@ repository = { workspace = true }
 
 [dependencies]
 # General
+log = { workspace = true }
 array-bytes = { workspace = true }
 
 # Substrate
@@ -27,12 +28,12 @@ bp-multi-sig = { workspace = true }
 [features]
 default = ["std"]
 std = [
-    "scale-info/std",
-    "parity-scale-codec/std",
-    "frame-support/std",
-    "frame-system/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "sp-core/std",
-    "bp-multi-sig/std",
+	"scale-info/std",
+	"parity-scale-codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"sp-core/std",
+	"bp-multi-sig/std",
 ]

--- a/pallets/btc-registration-pool/src/lib.rs
+++ b/pallets/btc-registration-pool/src/lib.rs
@@ -24,11 +24,8 @@ pub struct BitcoinRelayTarget<AccountId> {
 }
 
 impl<AccountId: PartialEq + Clone + Ord> BitcoinRelayTarget<AccountId> {
-	pub fn new<T: Config>(refund_address: BoundedBitcoinAddress) -> Self {
-		Self {
-			refund_address,
-			vault: MultiSigAccount::new(<RequiredM<T>>::get(), <RequiredN<T>>::get()),
-		}
+	pub fn new<T: Config>(refund_address: BoundedBitcoinAddress, m: u32, n: u32) -> Self {
+		Self { refund_address, vault: MultiSigAccount::new(m, n) }
 	}
 
 	pub fn set_vault_address(&mut self, address: BoundedBitcoinAddress) {

--- a/pallets/btc-registration-pool/src/lib.rs
+++ b/pallets/btc-registration-pool/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod migrations;
 mod pallet;
 pub mod weights;
 
@@ -13,6 +14,19 @@ use sp_core::RuntimeDebug;
 use bp_multi_sig::{BoundedBitcoinAddress, MultiSigAccount, Public};
 
 pub const ADDRESS_U64: u64 = 256;
+
+pub(crate) const LOG_TARGET: &'static str = "runtime::btc-registration-pool";
+
+// syntactic sugar for logging.
+#[macro_export]
+macro_rules! log {
+	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+		log::$level!(
+			target: crate::LOG_TARGET,
+			concat!("[{:?}] 💸 ", $patter), <frame_system::Pallet<T>>::block_number() $(, $values)*
+		)
+	};
+}
 
 #[derive(Decode, Encode, TypeInfo)]
 /// The registered Bitcoin relay target information.

--- a/pallets/btc-registration-pool/src/migrations.rs
+++ b/pallets/btc-registration-pool/src/migrations.rs
@@ -33,6 +33,9 @@ pub mod v2 {
 
 				<MultiSigRatio<T>>::put(Percent::from_percent(100));
 
+				// translate `BondedRefund` to vector.
+				<BondedRefund<T>>::translate(|_, old: T::AccountId| Some(vec![old]));
+
 				current.put::<Pallet<T>>();
 
 				weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 4));

--- a/pallets/btc-registration-pool/src/migrations.rs
+++ b/pallets/btc-registration-pool/src/migrations.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+pub mod v2 {
+	use core::marker::PhantomData;
+
+	use frame_support::{
+		pallet_prelude::ValueQuery, storage_alias, traits::GetStorageVersion,
+		traits::OnRuntimeUpgrade, weights::Weight,
+	};
+	use sp_core::Get;
+	use sp_runtime::Percent;
+
+	use super::*;
+
+	#[storage_alias]
+	pub type RequiredM<T: Config> = StorageValue<Pallet<T>, u8, ValueQuery>;
+
+	#[storage_alias]
+	pub type RequiredN<T: Config> = StorageValue<Pallet<T>, u8, ValueQuery>;
+
+	pub struct MigrateToV2<T>(PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV2<T> {
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			let mut weight = Weight::zero();
+
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = Pallet::<T>::on_chain_storage_version();
+
+			if current == 2 && onchain == 1 {
+				RequiredM::<T>::kill();
+				RequiredN::<T>::kill();
+
+				<MultiSigRatio<T>>::put(Percent::from_percent(100));
+
+				current.put::<Pallet<T>>();
+
+				weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 4));
+				log!(info, "btc-registration-pool storage migration passes v2 update ✅");
+			} else {
+				log!(warn, "Skipping btc-registration-pool storage migration v2 💤");
+				weight = weight.saturating_add(T::DbWeight::get().reads(1));
+			}
+
+			weight
+		}
+	}
+}

--- a/pallets/btc-registration-pool/src/pallet/mod.rs
+++ b/pallets/btc-registration-pool/src/pallet/mod.rs
@@ -1,13 +1,13 @@
 mod impls;
 
 use crate::{
-	BitcoinRelayTarget, BoundedBitcoinAddress, MultiSigAccount, VaultKeySubmission, WeightInfo,
-	ADDRESS_U64,
+	migrations, BitcoinRelayTarget, BoundedBitcoinAddress, MultiSigAccount, VaultKeySubmission,
+	WeightInfo, ADDRESS_U64,
 };
 
 use frame_support::{
 	pallet_prelude::*,
-	traits::{SortedMembers, StorageVersion},
+	traits::{OnRuntimeUpgrade, SortedMembers, StorageVersion},
 };
 use frame_system::pallet_prelude::*;
 
@@ -23,7 +23,7 @@ use sp_std::{str, vec};
 pub mod pallet {
 	use super::*;
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -143,6 +143,13 @@ pub mod pallet {
 	#[pallet::getter(fn required_n)]
 	/// The minimum required number of signatures to send a transaction with the vault account.
 	pub type MultiSigRatio<T: Config> = StorageValue<_, Percent, ValueQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_runtime_upgrade() -> Weight {
+			migrations::v2::MigrateToV2::<T>::on_runtime_upgrade()
+		}
+	}
 
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]

--- a/pallets/btc-registration-pool/src/weights.rs
+++ b/pallets/btc-registration-pool/src/weights.rs
@@ -9,7 +9,7 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for `pallet_btc_registration_pool`.
 pub trait WeightInfo {
-	fn set_vault_config() -> Weight;
+	fn set_minimum_sigs() -> Weight;
 	fn set_refund() -> Weight;
 	fn submit_vault_key() -> Weight;
 	fn submit_system_vault_key() -> Weight;
@@ -21,7 +21,7 @@ pub trait WeightInfo {
 /// Weights for `pallet_btc_registration_pool` using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn set_vault_config() -> Weight {
+	fn set_minimum_sigs() -> Weight {
 		Weight::from_parts(18_178_000, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
@@ -60,7 +60,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn set_vault_config() -> Weight {
+	fn set_minimum_sigs() -> Weight {
 		Weight::from_parts(18_178_000, 0)
 			.saturating_add(RocksDbWeight::get().reads(6 as u64))
 			.saturating_add(RocksDbWeight::get().writes(4 as u64))

--- a/pallets/btc-registration-pool/src/weights.rs
+++ b/pallets/btc-registration-pool/src/weights.rs
@@ -9,7 +9,6 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for `pallet_btc_registration_pool`.
 pub trait WeightInfo {
-	fn set_minimum_sigs() -> Weight;
 	fn set_refund() -> Weight;
 	fn submit_vault_key() -> Weight;
 	fn submit_system_vault_key() -> Weight;
@@ -21,11 +20,6 @@ pub trait WeightInfo {
 /// Weights for `pallet_btc_registration_pool` using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn set_minimum_sigs() -> Weight {
-		Weight::from_parts(18_178_000, 0)
-			.saturating_add(T::DbWeight::get().reads(6 as u64))
-			.saturating_add(T::DbWeight::get().writes(4 as u64))
-	}
 	fn set_refund() -> Weight {
 		Weight::from_parts(18_178_000, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
@@ -60,11 +54,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn set_minimum_sigs() -> Weight {
-		Weight::from_parts(18_178_000, 0)
-			.saturating_add(RocksDbWeight::get().reads(6 as u64))
-			.saturating_add(RocksDbWeight::get().writes(4 as u64))
-	}
 	fn set_refund() -> Weight {
 		Weight::from_parts(18_178_000, 0)
 			.saturating_add(RocksDbWeight::get().reads(6 as u64))

--- a/precompiles/btc-registration-pool/src/interface.sol
+++ b/precompiles/btc-registration-pool/src/interface.sol
@@ -79,14 +79,12 @@ interface BtcRegistrationPool {
         address user_bfc_address
     ) external view returns (string memory);
 
-    /// @dev Returns the bonded user address mapped to the given bitcoin address
-    /// @custom:selector e26af161
-    /// @param vault_or_refund the vault or refund address
-    /// @param is_vault the flag that represents whether the given address is a vault or refund
+    /// @dev Returns the bonded user address mapped to the given vault address
+    /// @custom:selector 257640e7
+    /// @param vault_address the vault address
     /// @return The users Bifrost address
     function user_address(
-        string memory vault_or_refund,
-        bool is_vault
+        string memory vault_address
     ) external view returns (address);
 
     /// @dev Returns the bonded descriptor(string) mapped to the given vault address

--- a/primitives/multi-sig/src/lib.rs
+++ b/primitives/multi-sig/src/lib.rs
@@ -4,9 +4,11 @@ pub mod traits;
 
 pub use miniscript::{
 	bitcoin::{
-		hashes::Hash, secp256k1::Secp256k1, Address, Network, Psbt, PublicKey, Script, Txid,
+		hashes::Hash, key::Error, secp256k1::Secp256k1, Address, Network, Psbt, PublicKey, Script,
+		Txid,
 	},
 	psbt::PsbtExt,
+	Descriptor,
 };
 
 use sp_core::{ConstU32, RuntimeDebug};
@@ -63,13 +65,13 @@ pub struct MultiSigAccount<AccountId> {
 	/// Public keys that the vault address contains.
 	pub pub_keys: BoundedBTreeMap<AccountId, Public, ConstU32<MULTI_SIG_MAX_ACCOUNTS>>,
 	/// The m value of the multi-sig address.
-	pub m: u8,
+	pub m: u32,
 	/// The n value of the multi-sig address.
-	pub n: u8,
+	pub n: u32,
 }
 
 impl<AccountId: PartialEq + Clone + Ord> MultiSigAccount<AccountId> {
-	pub fn new(m: u8, n: u8) -> Self {
+	pub fn new(m: u32, n: u32) -> Self {
 		Self {
 			address: AddressState::Pending,
 			descriptor: UnboundedBytes::default(),

--- a/primitives/multi-sig/src/traits.rs
+++ b/primitives/multi-sig/src/traits.rs
@@ -1,38 +1,6 @@
-use miniscript::{
-	bitcoin::{key::Error, Network, PublicKey},
-	Descriptor,
-};
+use miniscript::bitcoin::Network;
 
-use sp_std::{vec, vec::Vec};
-
-use crate::{BoundedBitcoinAddress, Public};
-
-pub trait MultiSigManager {
-	/// Check if the PSBT finalizable.
-	fn is_finalizable(m: u8) -> bool;
-
-	/// Convert string typed public keys to `PublicKey` type and return the sorted list.
-	fn sort_pub_keys(raw_pub_keys: Vec<Public>) -> Result<Vec<PublicKey>, Error> {
-		let mut pub_keys = vec![];
-		for raw_key in raw_pub_keys.iter() {
-			let key = PublicKey::from_slice(raw_key.as_ref())?;
-			pub_keys.push(key);
-		}
-		pub_keys.sort();
-		Ok(pub_keys)
-	}
-
-	fn generate_descriptor(
-		m: usize,
-		raw_pub_keys: Vec<Public>,
-	) -> Result<Descriptor<PublicKey>, ()> {
-		let desc =
-			Descriptor::new_wsh_sortedmulti(m, Self::sort_pub_keys(raw_pub_keys).map_err(|_| ())?)
-				.map_err(|_| ())?;
-		desc.sanity_check().map_err(|_| ())?;
-		Ok(desc)
-	}
-}
+use crate::BoundedBitcoinAddress;
 
 pub trait PoolManager<AccountId> {
 	/// Get the refund address of the given user.

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -144,7 +144,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 340,
+	spec_version: 341,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -981,6 +981,7 @@ impl pallet_btc_socket_queue::Config for Runtime {
 parameter_types! {
 	pub const BitcoinChainId: u32 = 10002;
 	pub const BitcoinNetwork: Network = Network::Regtest;
+	pub const DefaultMultiSigRatio: Percent = Percent::from_percent(100);
 }
 
 impl pallet_btc_registration_pool::Config for Runtime {
@@ -989,8 +990,7 @@ impl pallet_btc_registration_pool::Config for Runtime {
 	type Signature = EthereumSignature;
 	type Signer = EthereumSigner;
 	type Executives = RelayExecutiveMembership;
-	type DefaultRequiredM = ConstU8<2>;
-	type DefaultRequiredN = ConstU8<2>;
+	type DefaultMultiSigRatio = DefaultMultiSigRatio;
 	type BitcoinChainId = BitcoinChainId;
 	type BitcoinNetwork = BitcoinNetwork;
 	type WeightInfo = pallet_btc_registration_pool::weights::SubstrateWeight<Runtime>;

--- a/tests/tests/pallets/test_btc_registration_pool.ts
+++ b/tests/tests/pallets/test_btc_registration_pool.ts
@@ -121,7 +121,7 @@ describeDevNode('pallet_btc_registration_pool - request_vault', (context) => {
     await context.createBlock();
 
     const rawBondedRefund: any = await context.polkadotApi.query.btcRegistrationPool.bondedRefund(refund);
-    expect(rawBondedRefund.toJSON()).eq(baltathar.address);
+    expect(rawBondedRefund.toJSON()[0]).eq(baltathar.address);
 
     const rawRegisteredBitcoinPair: any = await context.polkadotApi.query.btcRegistrationPool.registrationPool(baltathar.address);
     const registeredBitcoinPair = rawRegisteredBitcoinPair.toHuman();
@@ -136,8 +136,8 @@ describeDevNode('pallet_btc_registration_pool - request_vault', (context) => {
     await context.polkadotApi.tx.btcRegistrationPool.requestVault(refund).signAndSend(charleth);
     await context.createBlock();
 
-    const extrinsicResult = await getExtrinsicResult(context, 'btcRegistrationPool', 'requestVault');
-    expect(extrinsicResult).eq('AddressAlreadyRegistered');
+    const rawBondedRefund: any = await context.polkadotApi.query.btcRegistrationPool.bondedRefund(refund);
+    expect(rawBondedRefund.toJSON()[1]).eq(charleth.address);
   });
 
   it('should fail to join registration pool due to duplicate user address', async function () {
@@ -267,7 +267,7 @@ describeDevNode('pallet_btc_registration_pool - submit_key (1-of-1)', (context) 
 
     const rawBondedRefund: any = await context.polkadotApi.query.btcRegistrationPool.bondedRefund(refund);
     const bondedRefund = rawBondedRefund.toHuman();
-    expect(bondedRefund).is.null;
+    expect(bondedRefund).is.empty;
 
     const rawBondedDescriptor: any = await context.polkadotApi.query.btcRegistrationPool.bondedDescriptor(vault);
     const bondedDescriptor = rawBondedDescriptor.toHuman();


### PR DESCRIPTION
## Description

### Changes
- Use dynamic multi-sig `m-of-n`
  - `n`: relay Exec count
  - `m`: ratio * `n`
- Allow duplicate refund addresses
- Check psbt finalization on every signed psbt submission

### Todo
- Relayer Abi update

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
