### PR TITLE
NODE-104, feat: staking precompile update

### DIFF
--- a/precompiles/bfc-staking/src/interface.sol
+++ b/precompiles/bfc-staking/src/interface.sol
@@ -81,30 +81,30 @@ interface BfcStaking {
     /// @param candidate the address that we want to confirm is a validator andidate
     /// @param tier the type of the validator candidate (0: All, 1: Basic, 2: Full)
     /// @return A boolean confirming whether the address is a validator candidate
-    function is_candidate(address candidate, uint256 tier)
-        external
-        view
-        returns (bool);
+    function is_candidate(
+        address candidate,
+        uint256 tier
+    ) external view returns (bool);
 
     /// @dev Check whether the specified address is currently a part of the active set (full or basic)
     /// Selector: 4a079cfd
     /// @param candidate the address that we want to confirm is a part of the active set
     /// @param tier the type of the validator candidate (0: All, 1: Basic, 2: Full)
     /// @return A boolean confirming whether the address is a part of the active set
-    function is_selected_candidate(address candidate, uint256 tier)
-        external
-        view
-        returns (bool);
+    function is_selected_candidate(
+        address candidate,
+        uint256 tier
+    ) external view returns (bool);
 
     /// @dev Check whether the specified address elements is currently a part of the active set
     /// Selector: 044527bd
     /// @param candidates the address array that we want to confirm is a part of the active set
     /// @param tier the type of the validator candidate (0: All, 1: Basic, 2: Full)
     /// @return A boolean confirming whether the address array is a part of the active set
-    function is_selected_candidates(address[] calldata candidates, uint256 tier)
-        external
-        view
-        returns (bool);
+    function is_selected_candidates(
+        address[] calldata candidates,
+        uint256 tier
+    ) external view returns (bool);
 
     /// @dev Check whether every specified address element is currently the active set (full or basic)
     /// Selector: 2e8c2a6a
@@ -176,10 +176,9 @@ interface BfcStaking {
     /// @dev Get the given rounds active validator sets majority
     /// Selector: e0f9ab40
     /// @return The given rounds majority
-    function previous_majority(uint256 round_index)
-        external
-        view
-        returns (uint256);
+    function previous_majority(
+        uint256 round_index
+    ) external view returns (uint256);
 
     /// @dev Total points awarded to all validators in a particular round
     /// Selector: 9799b4e7
@@ -191,10 +190,10 @@ interface BfcStaking {
     /// Selector: 59a595fb
     /// @param round_index the round for which we are querying the points
     /// @return The awarded points to the validator in the given round
-    function validator_points(uint256 round_index, address validator)
-        external
-        view
-        returns (uint256);
+    function validator_points(
+        uint256 round_index,
+        address validator
+    ) external view returns (uint256);
 
     /// @dev The amount of awarded tokens to validators and nominators since genesis
     /// Selector: 9ec5a894
@@ -204,10 +203,9 @@ interface BfcStaking {
     /// @dev Total capital locked information of self-bonds and nominations of the given round
     /// Selector: b119ebfe
     /// @return The total locked information
-    function total(uint256 round_index)
-        external
-        view
-        returns (total_stake memory);
+    function total(
+        uint256 round_index
+    ) external view returns (total_stake memory);
 
     /// @dev Stake annual inflation parameters
     /// Selector: 10db2de9
@@ -215,11 +213,7 @@ interface BfcStaking {
     function inflation_config()
         external
         view
-        returns (
-            uint256,
-            uint256,
-            uint256
-        );
+        returns (uint256, uint256, uint256);
 
     /// @dev Stake annual inflation rate
     /// Selector: 180692d0
@@ -230,6 +224,15 @@ interface BfcStaking {
     /// Selector: fd0c6dc1
     /// @return The estimated yearly return according to the requested data
     function estimated_yearly_return(
+        address[] memory candidates,
+        uint256[] memory amounts
+    ) external view returns (uint256[] memory);
+
+    /// @dev The estimated yearly return on bond less
+    /// Selector: f579bfe5
+    /// @return The estimated yearly return according to the requested data
+    function estimated_yearly_return_on_bond_less(
+        address nominator,
         address[] memory candidates,
         uint256[] memory amounts
     ) external view returns (uint256[] memory);
@@ -266,11 +269,7 @@ interface BfcStaking {
     function nominator_bond_less_delay()
         external
         view
-        returns (
-            uint256,
-            uint256,
-            uint256
-        );
+        returns (uint256, uint256, uint256);
 
     /// @dev Get the CandidateCount weight hint
     /// Selector: 4b1c4c29
@@ -281,18 +280,16 @@ interface BfcStaking {
     /// Selector: a5542eea
     /// @param tier the type of the validator candidate (0: All, 1: Basic, 2: Full)
     /// @return The list of the selected candidates
-    function selected_candidates(uint256 tier)
-        external
-        view
-        returns (address[] memory);
+    function selected_candidates(
+        uint256 tier
+    ) external view returns (address[] memory);
 
     /// @dev Get the previous selected candidates of the given round index
     /// Selector: d9c62dc8
     /// @return The list of the previous selected candidates
-    function previous_selected_candidates(uint256 round_index)
-        external
-        view
-        returns (address[] memory);
+    function previous_selected_candidates(
+        uint256 round_index
+    ) external view returns (address[] memory);
 
     /// @dev Get the current state of joined validator candidates
     /// Selector: 96b41b5b
@@ -306,16 +303,17 @@ interface BfcStaking {
     /// Selector: 36f3b497
     /// @param candidate the address for which we are querying the state
     /// @return The current state of the queried candidate
-    function candidate_state(address candidate)
-        external
-        view
-        returns (candidate_meta_data memory);
+    function candidate_state(
+        address candidate
+    ) external view returns (candidate_meta_data memory);
 
     /// @dev Get every candidate states
     /// Selector: 3b368c8c
     /// @param tier the type of the validator candidate (0: All, 1: Basic, 2: Full)
     /// @return An array of every candidate states
-    function candidate_states(uint256 tier)
+    function candidate_states(
+        uint256 tier
+    )
         external
         view
         returns (
@@ -346,7 +344,10 @@ interface BfcStaking {
     /// @param tier the type of the validator candidate (0: All, 1: Basic, 2: Full)
     /// @param is_selected the boolean for which it is selected for the current round
     /// @return An array of every candidate states that matches the selector
-    function candidate_states_by_selection(uint256 tier, bool is_selected)
+    function candidate_states_by_selection(
+        uint256 tier,
+        bool is_selected
+    )
         external
         view
         returns (
@@ -376,53 +377,47 @@ interface BfcStaking {
     /// Selector: 2e388768
     /// @param candidate the address for which we are querying the state
     /// @return The current status of the queried candidate
-    function candidate_request(address candidate)
-        external
-        view
-        returns (candidate_request_data memory);
+    function candidate_request(
+        address candidate
+    ) external view returns (candidate_request_data memory);
 
     /// @dev Get the top nominations of the given candidate
     /// Selector: 2a9cdf2b
     /// @param candidate the address for which we are querying the state
     /// @return The current status of the queried candidate
-    function candidate_top_nominations(address candidate)
+    function candidate_top_nominations(
+        address candidate
+    )
         external
         view
-        returns (
-            address,
-            uint256,
-            address[] memory,
-            uint256[] memory
-        );
+        returns (address, uint256, address[] memory, uint256[] memory);
 
     /// @dev Get the bottom nominations of the given candidate
     /// Selector: 9be794c0
     /// @param candidate the address for which we are querying the state
     /// @return The current status of the queried candidate
-    function candidate_bottom_nominations(address candidate)
+    function candidate_bottom_nominations(
+        address candidate
+    )
         external
         view
-        returns (
-            address,
-            uint256,
-            address[] memory,
-            uint256[] memory
-        );
+        returns (address, uint256, address[] memory, uint256[] memory);
 
     /// @dev Get the CandidateNominationCount weight hint
     /// Selector: 1c8ad6fe
     /// @param candidate The address for which we are querying the nomination count
     /// @return The number of nominations backing the validator
-    function candidate_nomination_count(address candidate)
-        external
-        view
-        returns (uint256);
+    function candidate_nomination_count(
+        address candidate
+    ) external view returns (uint256);
 
     /// @dev Get the current state of the given nominator
     /// Selector: 3f97be51
     /// @param nominator the address for which we are querying the state
     /// @return The current state of the queried nominator
-    function nominator_state(address nominator)
+    function nominator_state(
+        address nominator
+    )
         external
         view
         returns (
@@ -443,7 +438,9 @@ interface BfcStaking {
     /// Selector: 24f81326
     /// @param nominator the address for which we are querying the state
     /// @return The pending requests of the queried nominator
-    function nominator_requests(address nominator)
+    function nominator_requests(
+        address nominator
+    )
         external
         view
         returns (
@@ -460,10 +457,9 @@ interface BfcStaking {
     /// Selector: dae5659b
     /// @param nominator The address for which we are querying the nomination count
     /// @return The number of nominations made by the nominator
-    function nominator_nomination_count(address nominator)
-        external
-        view
-        returns (uint256);
+    function nominator_nomination_count(
+        address nominator
+    ) external view returns (uint256);
 
     /// @dev Temporarily leave the set of validator candidates without unbonding
     /// Selector: 767e0450
@@ -504,8 +500,9 @@ interface BfcStaking {
     /// @dev Execute due request to leave the set of validator candidates
     /// Selector: e33a8f25
     /// @param candidateNominationCount The number of nominations for the candidate to be revoked
-    function execute_leave_candidates(uint256 candidateNominationCount)
-        external;
+    function execute_leave_candidates(
+        uint256 candidateNominationCount
+    ) external;
 
     /// @dev Execute pending candidate bond request
     /// Selector: 6c76b502
@@ -566,14 +563,17 @@ interface BfcStaking {
     /// Selector: 774bef4d
     /// @param candidate The address of the validator candidate for which nomination shall decrease
     /// @param less The amount by which the nomination is decreased (upon execution)
-    function schedule_nominator_bond_less(address candidate, uint256 less)
-        external;
+    function schedule_nominator_bond_less(
+        address candidate,
+        uint256 less
+    ) external;
 
     /// @dev Execute request to leave the set of nominators and revoke all nominations
     /// Selector: 4480de22
     /// @param nominatorNominationCount The number of active nominations to be revoked by nominator
-    function execute_leave_nominators(uint256 nominatorNominationCount)
-        external;
+    function execute_leave_nominators(
+        uint256 nominatorNominationCount
+    ) external;
 
     /// @dev Execute pending nomination request (if exists && is due)
     /// Selector: bfb13332

--- a/precompiles/bfc-staking/src/interface.sol
+++ b/precompiles/bfc-staking/src/interface.sol
@@ -229,7 +229,7 @@ interface BfcStaking {
     ) external view returns (uint256[] memory);
 
     /// @dev The estimated yearly return
-    /// Selector:
+    /// Selector: 062e4041
     /// @return The estimated yearly return according to the requested data
     function get_estimated_yearly_return(
         uint256 method,

--- a/precompiles/bfc-staking/src/interface.sol
+++ b/precompiles/bfc-staking/src/interface.sol
@@ -228,10 +228,11 @@ interface BfcStaking {
         uint256[] memory amounts
     ) external view returns (uint256[] memory);
 
-    /// @dev The estimated yearly return on bond less
-    /// Selector: f579bfe5
+    /// @dev The estimated yearly return
+    /// Selector:
     /// @return The estimated yearly return according to the requested data
-    function estimated_yearly_return_on_bond_less(
+    function get_estimated_yearly_return(
+        uint256 method,
         address nominator,
         address[] memory candidates,
         uint256[] memory amounts

--- a/precompiles/bfc-staking/src/lib.rs
+++ b/precompiles/bfc-staking/src/lib.rs
@@ -474,7 +474,8 @@ where
 				let commission = validator_contribution_pct * validator_issuance;
 				let amount_due = total_reward_amount - commission;
 
-				let nominator_stake_pct = Perbill::from_rational(amounts[idx], state.voting_power);
+				let nominator_stake_pct =
+					Perbill::from_rational(amounts[idx], state.voting_power + amounts[idx]);
 				estimated_yearly_return.push(
 					((nominator_stake_pct * amount_due) * rounds_per_year.into())
 						.try_into()

--- a/precompiles/bfc-staking/src/lib.rs
+++ b/precompiles/bfc-staking/src/lib.rs
@@ -472,7 +472,7 @@ where
 
 		for (idx, candidate) in candidates.iter().enumerate() {
 			let candidate_state = <StakingOf<Runtime>>::candidate_info(&candidate)
-				.ok_or(RevertReason::custom("Candidate does not exist").into())?;
+				.ok_or(RevertReason::custom("Candidate does not exist"))?;
 			let nominator_stake_pct = Perbill::from_rational(
 				Self::get_eyr_nomination(method, &nominator, &candidate, amounts[idx])?,
 				match method {

--- a/precompiles/bfc-staking/src/types.rs
+++ b/precompiles/bfc-staking/src/types.rs
@@ -12,6 +12,30 @@ use bp_staking::TierType;
 use sp_core::{H160, U256};
 use sp_std::{vec, vec::Vec};
 
+#[derive(Clone, Copy)]
+/// The estimation method.
+pub enum EyrMethod {
+	/// Estimates the yearly return of a new nomination.
+	Nominate,
+	/// Estimates the yearly return of a bond more for existing nominations.
+	BondMore,
+	/// Estimates the yearly return of a bond less for existing nominations.
+	BondLess,
+}
+
+impl TryFrom<u32> for EyrMethod {
+	type Error = ();
+
+	fn try_from(value: u32) -> Result<Self, Self::Error> {
+		match value {
+			0 => Ok(EyrMethod::Nominate),
+			1 => Ok(EyrMethod::BondMore),
+			2 => Ok(EyrMethod::BondLess),
+			_ => Err(()),
+		}
+	}
+}
+
 pub type BalanceOf<Runtime> = <<Runtime as pallet_bfc_staking::Config>::Currency as Currency<
 	<Runtime as frame_system::Config>::AccountId,
 >>::Balance;

--- a/tests/tests/precompiles/test_balances.ts
+++ b/tests/tests/precompiles/test_balances.ts
@@ -21,7 +21,7 @@ describeDevNode('precompile_balances - precompile view functions', (context) => 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'total_issuance',
-      [],
+      '',
     );
     const decoded_total_issuance = context.web3.eth.abi.decodeParameters(
       ['uint256'],

--- a/tests/tests/precompiles/test_bfc_offences.ts
+++ b/tests/tests/precompiles/test_bfc_offences.ts
@@ -22,7 +22,7 @@ describeDevNode('precompile_bfc_offences - precompile view functions', (context)
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'maximum_offence_count',
-      ['0x0'],
+      context.web3.eth.abi.encodeParameter('uint256', '0x0'),
     );
     const decoded_maximum_offence_count: any = context.web3.eth.abi.decodeParameters(
       ['uint256[]'],
@@ -37,7 +37,7 @@ describeDevNode('precompile_bfc_offences - precompile view functions', (context)
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'validator_offence',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_validator_offence: any = context.web3.eth.abi.decodeParameters(
       ['tuple(address,uint256,uint256,uint256)'],
@@ -51,9 +51,7 @@ describeDevNode('precompile_bfc_offences - precompile view functions', (context)
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'validator_offences',
-      [
-        context.web3.eth.abi.encodeParameter('address[]', [alith.public])
-      ],
+      context.web3.eth.abi.encodeParameter('address[]', [alith.public]),
     );
     const decoded_validator_offences: any = context.web3.eth.abi.decodeParameters(
       ['address[]', 'uint256[]', 'uint256[]', 'uint256[]'],

--- a/tests/tests/precompiles/test_bfc_staking.ts
+++ b/tests/tests/precompiles/test_bfc_staking.ts
@@ -2,7 +2,9 @@ import BigNumber from 'bignumber.js';
 import { expect } from 'chai';
 import { numberToHex } from 'web3-utils';
 
-import { MIN_FULL_CANDIDATE_STAKING_AMOUNT } from '../../constants/currency';
+import {
+  MIN_FULL_CANDIDATE_STAKING_AMOUNT, MIN_NOMINATOR_STAKING_AMOUNT
+} from '../../constants/currency';
 import {
   TEST_CONTROLLERS, TEST_RELAYERS, TEST_STASHES
 } from '../../constants/keys';
@@ -32,6 +34,7 @@ const SELECTORS = {
   inflation_config: '10db2de9',
   inflation_rate: '180692d0',
   estimated_yearly_return: 'fd0c6dc1',
+  get_estimated_yearly_return: '062e4041',
   min_nomination: 'c9f593b2',
   max_nominations_per_nominator: '8b88f0e1',
   max_nominations_per_candidate: '547eaba9',
@@ -90,7 +93,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_candidate',
-      [alith.public, '0x0'],
+      context.web3.eth.abi.encodeParameters(['address', 'uint256'], [alith.public, '0x0']),
     );
     const decoded_is_candidate = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -104,7 +107,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_selected_candidate',
-      [alith.public, '0x0'],
+      context.web3.eth.abi.encodeParameters(['address', 'uint256'], [alith.public, '0x0']),
     );
     const decoded_is_selected_candidate = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -118,7 +121,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_previous_selected_candidate',
-      ['0x1', alith.public],
+      context.web3.eth.abi.encodeParameters(['uint256', 'address'], ['0x1', alith.public]),
     );
     const decoded_is_previous_selected_candidate = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -134,7 +137,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'round_info',
-      [],
+      '',
     );
     const decoded_round_info: any = context.web3.eth.abi.decodeParameters(
       ['tuple(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)'],
@@ -148,7 +151,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'latest_round',
-      [],
+      '',
     );
     const decoded_latest_round = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -162,7 +165,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'majority',
-      [],
+      '',
     );
     const decoded_majority = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -176,7 +179,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'previous_majority',
-      ['0x1'],
+      context.web3.eth.abi.encodeParameter('uint256', '0x1'),
     );
     const decoded_previous_majority = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -191,7 +194,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'points',
-      ['0x1'],
+      context.web3.eth.abi.encodeParameter('uint256', '0x1'),
     );
     const decoded_points = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -205,7 +208,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'validator_points',
-      ['0x1', alith.public],
+      context.web3.eth.abi.encodeParameters(['uint256', 'address'], ['0x1', alith.public]),
     );
     const decoded_validator_points = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -220,7 +223,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'rewards',
-      [],
+      '',
     );
     const decoded_rewards = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -234,7 +237,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'total',
-      ['0x2'],
+      context.web3.eth.abi.encodeParameter('uint256', '0x2'),
     );
     const decoded_total: any = context.web3.eth.abi.decodeParameters(
       [
@@ -250,7 +253,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'inflation_config',
-      [],
+      '',
     );
     const decoded_inflation_config = context.web3.eth.abi.decodeParameters(
       ['uint256', 'uint256', 'uint256'],
@@ -267,7 +270,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'inflation_rate',
-      [],
+      '',
     );
     const decoded_inflation_rate = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -281,7 +284,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'min_nomination',
-      [],
+      '',
     );
     const decoded_min_nomination = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -295,7 +298,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'max_nominations_per_nominator',
-      [],
+      '',
     );
     const decoded_max_nominations_per_nominator = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -309,7 +312,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'max_nominations_per_candidate',
-      [],
+      '',
     );
     const decoded_max_nominations_per_candidate = context.web3.eth.abi.decodeParameters(
       ['uint256', 'uint256'],
@@ -325,7 +328,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_bond_less_delay',
-      [],
+      '',
     );
     const decoded_candidate_bond_less_delay = context.web3.eth.abi.decodeParameters(
       ['uint256', 'uint256'],
@@ -341,7 +344,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'nominator_bond_less_delay',
-      [],
+      '',
     );
     const decoded_nominator_bond_less_delay = context.web3.eth.abi.decodeParameters(
       ['uint256', 'uint256', 'uint256'],
@@ -360,7 +363,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_count',
-      [],
+      '',
     );
     const decoded_candidate_count = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -374,7 +377,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'selected_candidates',
-      ['0x0'],
+      context.web3.eth.abi.encodeParameter('uint256', '0x0'),
     );
     const decoded_selected_candidates: any = context.web3.eth.abi.decodeParameters(
       ['address[]'],
@@ -389,7 +392,8 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'previous_selected_candidates',
-      ['0x2'],
+      context.web3.eth.abi.encodeParameter('uint256', '0x2'),
+
     );
     const decoded_previous_selected_candidates: any = context.web3.eth.abi.decodeParameters(
       ['address[]'],
@@ -404,7 +408,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_pool',
-      [],
+      '',
     );
     const decoded_candidate_pool: any = context.web3.eth.abi.decodeParameters(
       ['address[]', 'uint256[]'],
@@ -420,7 +424,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_state',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_candidate_state: any = context.web3.eth.abi.decodeParameters(
       [
@@ -436,7 +440,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_states',
-      ['0x0'],
+      context.web3.eth.abi.encodeParameter('uint256', '0x0'),
     );
     const decoded_candidate_states: any = context.web3.eth.abi.decodeParameters(
       [
@@ -471,7 +475,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_states_by_selection',
-      ['0x0', '0x1'],
+      context.web3.eth.abi.encodeParameters(['uint256', 'bool'], ['0x0', true]),
     );
     const decoded_candidate_states_by_selection: any = context.web3.eth.abi.decodeParameters(
       [
@@ -506,7 +510,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_request',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_candidate_request: any = context.web3.eth.abi.decodeParameters(
       [
@@ -522,7 +526,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_top_nominations',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_candidate_top_nominations = context.web3.eth.abi.decodeParameters(
       [
@@ -541,7 +545,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_bottom_nominations',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_candidate_bottom_nominations = context.web3.eth.abi.decodeParameters(
       [
@@ -560,7 +564,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_nomination_count',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_candidate_nomination_count = context.web3.eth.abi.decodeParameters(
       [
@@ -578,7 +582,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'nominator_state',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_nominator_state = context.web3.eth.abi.decodeParameters(
       [
@@ -604,7 +608,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'nominator_requests',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_nominator_requests = context.web3.eth.abi.decodeParameters(
       [
@@ -626,7 +630,7 @@ describeDevNode('precompile_bfc_staking - precompile view functions', (context) 
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'nominator_nomination_count',
-      [alith.public],
+      context.web3.eth.abi.encodeParameter('address', alith.public),
     );
     const decoded_nominator_nomination_count = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -642,6 +646,8 @@ describeDevNode('precompile_bfc_staking - precompile dispatch functions', (conte
   const baltathar: { public: string, private: string } = TEST_CONTROLLERS[1];
   const baltatharStash: { public: string, private: string } = TEST_STASHES[1];
   const baltatharRelayer: { public: string, private: string } = TEST_RELAYERS[1];
+
+  const charleth: { public: string, private: string } = TEST_CONTROLLERS[2];
 
   it('should successfully execute `join_candidates()`', async function () {
     const stake = new BigNumber(MIN_FULL_CANDIDATE_STAKING_AMOUNT);
@@ -665,7 +671,7 @@ describeDevNode('precompile_bfc_staking - precompile dispatch functions', (conte
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_pool',
-      [],
+      '',
     );
     const decoded_candidate_pool: any = context.web3.eth.abi.decodeParameters(
       ['address[]', 'uint256[]'],
@@ -698,7 +704,7 @@ describeDevNode('precompile_bfc_staking - precompile dispatch functions', (conte
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'candidate_state',
-      [baltathar.public],
+      context.web3.eth.abi.encodeParameter('address', baltathar.public),
     );
     const decoded_candidate_state: any = context.web3.eth.abi.decodeParameters(
       [
@@ -707,6 +713,51 @@ describeDevNode('precompile_bfc_staking - precompile dispatch functions', (conte
       candidate_state,
     )[0];
     expect(new BigNumber(decoded_candidate_state[2]).toFixed()).equal(new BigNumber(more).multipliedBy(2).toFixed());
+  });
+
+  it('should successfully execute `nominate()`', async function () {
+    const nomination = new BigNumber(MIN_NOMINATOR_STAKING_AMOUNT);
+
+    const block = await sendPrecompileTx(
+      context,
+      PRECOMPILE_ADDRESS,
+      SELECTORS,
+      charleth.public,
+      charleth.private,
+      'nominate',
+      [alith.public, numberToHex(nomination.toFixed()), numberToHex(1000), numberToHex(1000)],
+    );
+
+    const receipt = await context.web3.eth.getTransactionReceipt(block.txResults[0]);
+    expect(Boolean(receipt.status)).equal(true);
+  });
+
+  it('should successfully verify estimated yearly return', async function () {
+    const nomination = new BigNumber(MIN_NOMINATOR_STAKING_AMOUNT);
+
+    const estimated_yearly_return = await callPrecompile(
+      context,
+      charleth.public,
+      PRECOMPILE_ADDRESS,
+      SELECTORS,
+      'get_estimated_yearly_return',
+      context.web3.eth.abi.encodeParameters(
+        ['uint256', 'address', 'address[]', 'uint256[]'],
+        [
+          numberToHex(1),
+          charleth.public,
+          [alith.public],
+          [numberToHex(nomination.toFixed())],
+        ],
+      ),
+    );
+    const decoded_estimated_yearly_return = context.web3.eth.abi.decodeParameters(
+      [
+        'uint256[]',
+      ],
+      estimated_yearly_return,
+    )[0];
+    expect(Number(decoded_estimated_yearly_return)).gte(1);
   });
 });
 

--- a/tests/tests/precompiles/test_governance.ts
+++ b/tests/tests/precompiles/test_governance.ts
@@ -38,7 +38,7 @@ describeDevNode('precompile_governance - precompile actions', (context) => {
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'public_prop_count',
-      [],
+      '',
     );
     const decoded_public_prop_count = context.web3.eth.abi.decodeParameters(
       ['uint256'],

--- a/tests/tests/precompiles/test_relay_manager.ts
+++ b/tests/tests/precompiles/test_relay_manager.ts
@@ -41,7 +41,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_relayer',
-      [alithRelayer.public],
+      context.web3.eth.abi.encodeParameter('address', alithRelayer.public),
     );
     const decoded_is_relayer = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -55,7 +55,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_selected_relayer',
-      [alithRelayer.public, '0x1'],
+      context.web3.eth.abi.encodeParameters(['address', 'bool'], [alithRelayer.public, true]),
     );
     const decoded_is_selected_relayer = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -69,9 +69,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_relayers',
-      [
-        context.web3.eth.abi.encodeParameter('address[]', [alithRelayer.public]),
-      ],
+      context.web3.eth.abi.encodeParameter('address[]', [alithRelayer.public]),
     );
     const decoded_is_relayers = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -85,10 +83,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_selected_relayers',
-      [
-        context.web3.eth.abi.encodeParameter('address[]', [alithRelayer.public]),
-        '0x1',
-      ],
+      context.web3.eth.abi.encodeParameters(['address[]', 'bool'], [[alithRelayer.public], true]),
     );
     const decoded_is_selected_relayers = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -102,10 +97,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_complete_selected_relayers',
-      [
-        context.web3.eth.abi.encodeParameter('address[]', [alithRelayer.public]),
-        '0x1',
-      ],
+      context.web3.eth.abi.encodeParameters(['address[]', 'bool'], [[alithRelayer.public], true]),
     );
     const decoded_is_complete_selected_relayers = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -119,11 +111,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'is_previous_selected_relayer',
-      [
-        '0x1',
-        alithRelayer.public,
-        '0x1',
-      ],
+      context.web3.eth.abi.encodeParameters(['uint256', 'address', 'bool'], ['0x1', alithRelayer.public, true]),
     );
     const decoded_is_previous_selected_relayer = context.web3.eth.abi.decodeParameters(
       ['bool'],
@@ -139,7 +127,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'selected_relayers',
-      ['0x1'],
+      context.web3.eth.abi.encodeParameter('bool', true),
     );
     const decoded_selected_relayers: any = context.web3.eth.abi.decodeParameters(
       ['address[]'],
@@ -154,7 +142,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'previous_selected_relayers',
-      ['0x1', '0x1'],
+      context.web3.eth.abi.encodeParameters(['uint256', 'bool'], ['0x1', true]),
     );
     const decoded_previous_selected_relayers: any = context.web3.eth.abi.decodeParameters(
       ['address[]'],
@@ -169,7 +157,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'relayer_pool',
-      [],
+      '',
     );
     const decoded_relayer_pool: any = context.web3.eth.abi.decodeParameters(
       ['address[]', 'address[]'],
@@ -183,7 +171,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'majority',
-      ['0x1'],
+      context.web3.eth.abi.encodeParameter('bool', true),
     );
     const decoded_majority = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -197,7 +185,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'previous_majority',
-      ['0x1', '0x1'],
+      context.web3.eth.abi.encodeParameters(['uint256', 'bool'], ['0x1', true]),
     );
     const decoded_previous_majority = context.web3.eth.abi.decodeParameters(
       ['uint256'],
@@ -211,7 +199,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'relayer_state',
-      [alithRelayer.public],
+      context.web3.eth.abi.encodeParameter('address', alithRelayer.public),
     );
     const decoded_relayer_state: any = context.web3.eth.abi.decodeParameters(
       ['tuple(address,address,uint256)'],
@@ -225,7 +213,7 @@ describeDevNode('precompile_relay_manager - precompile view functions', (context
       PRECOMPILE_ADDRESS,
       SELECTORS,
       'relayer_states',
-      [],
+      '',
     );
     const decoded_relayer_states: any = context.web3.eth.abi.decodeParameters(
       ['address[]', 'address[]', 'uint256[]'],

--- a/tests/tests/transactions.ts
+++ b/tests/tests/transactions.ts
@@ -49,7 +49,7 @@ export async function callPrecompile(
   precompileContractAddress: string,
   selectors: { [key: string]: string },
   selector: string,
-  parameters: string[]
+  inputs: string
 ) {
   let data: string;
   if (selectors[selector]) {
@@ -57,9 +57,7 @@ export async function callPrecompile(
   } else {
     throw new Error(`selector doesn't exist on the precompile contract`);
   }
-  parameters.forEach((para: string) => {
-    data += para.slice(2).padStart(64, '0');
-  });
+  data += inputs.slice(2);
 
   return await customWeb3Request(context.web3, 'eth_call', [
     {


### PR DESCRIPTION
## Description

### Changes
- 기존에 존재했던 함수인 `estimated_yearly_return()` 함수 로직 일부 수정
  - input으로 입력된 amount가 결과값 계산 시, total stake와 voting power에도 반영될 수 있도록 수정
  - 해당 함수는 deprecated 명시함.
- 위의 함수의 기능과 추가적인 기능을 통합적으로 가진 새로운 함수인 `get_estimated_yearly_return()` 추가
  - 함수의 input 파라미터인 `method`를 통해 총 세가지의 기능을 가짐
    - `Nominate`: 현재 nominator가 아니고, 새롭게 참여할 경우에 대한 EYR을 계산
    - `BondMore`: 현재 nominator이고, 추가 예치할 경우에 대한 EYR을 계산
    - `BondLess`: 현재 nominator이고, 일부 출금할 경우에 대한 EYR을 계산

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
