### PR TITLE
fix: simply use txid instead of psbt bytes

### DIFF
--- a/pallets/btc-socket-queue/src/lib.rs
+++ b/pallets/btc-socket-queue/src/lib.rs
@@ -195,8 +195,8 @@ pub struct RollbackPsbtMessage<AccountId> {
 pub struct RollbackPollMessage<AccountId> {
 	/// The authority's account address.
 	pub authority_id: AccountId,
-	/// The unsigned PSBT (in bytes).
-	pub unsigned_psbt: UnboundedBytes,
+	/// The rollback PSBT's txid.
+	pub txid: H256,
 	/// The voting side. Approved or not.
 	pub is_approved: bool,
 }

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -144,7 +144,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 349,
+	spec_version: 350,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.


### PR DESCRIPTION
## Description

- Update `RollbackPollMessage`
  - use txid instead of psbt bytes
- cc. https://github.com/bifrost-platform/bifrost-relayer.rs/pull/138

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
