### PR TITLE
NODE-123, let sequence id to psbt txid available

### DIFF
--- a/pallets/btc-socket-queue/src/migrations.rs
+++ b/pallets/btc-socket-queue/src/migrations.rs
@@ -1,5 +1,103 @@
 use super::*;
 
+pub mod v2 {
+	use super::*;
+	use core::marker::PhantomData;
+	use frame_support::{
+		traits::{Get, GetStorageVersion, OnRuntimeUpgrade},
+		weights::Weight,
+	};
+
+	pub struct V2<T>(PhantomData<T>);
+
+	impl<T> OnRuntimeUpgrade for V2<T>
+	where
+		T: Config,
+		T::AccountId: Into<H160>,
+		H160: Into<T::AccountId>,
+	{
+		fn on_runtime_upgrade() -> Weight {
+			let mut weight = Weight::zero();
+
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = Pallet::<T>::on_chain_storage_version();
+
+			weight = weight.saturating_add(T::DbWeight::get().reads(2));
+
+			let mut count: u32 = 0;
+
+			if current == 2 && onchain == 1 {
+				<SocketMessages<T>>::translate(|_, old: SocketMessage| {
+					weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+
+					Some((H256::zero(), old))
+				});
+
+				log!(
+					info,
+					"btc-socket-queue current socket messages count: {:?} ✅",
+					<SocketMessages<T>>::iter_keys().count()
+				);
+
+				let mut insert_txid =
+					|raw_msg: UnboundedBytes, txid: H256, mut weight: Weight| -> Weight {
+						match Pallet::<T>::try_decode_socket_message(&raw_msg) {
+							Ok(msg) => {
+								if let Some(translated) =
+									<SocketMessages<T>>::get(&msg.req_id.sequence)
+								{
+									<SocketMessages<T>>::insert(
+										msg.req_id.sequence,
+										(txid, translated.1),
+									);
+									weight = weight
+										.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+
+									count = count.saturating_add(1);
+								} else {
+									log!(warn, "not found: {:?}", &msg.req_id.sequence);
+								}
+							},
+							Err(_) => {
+								log!(warn, "decode failed");
+							},
+						}
+						weight
+					};
+
+				for request in <PendingRequests<T>>::iter() {
+					weight = weight.saturating_add(T::DbWeight::get().reads(1));
+
+					for raw_msg in request.1.socket_messages {
+						weight = insert_txid(raw_msg, request.0, weight);
+					}
+				}
+				for request in <FinalizedRequests<T>>::iter() {
+					weight = weight.saturating_add(T::DbWeight::get().reads(1));
+
+					for raw_msg in request.1.socket_messages {
+						weight = insert_txid(raw_msg, request.0, weight);
+					}
+				}
+				for request in <ExecutedRequests<T>>::iter() {
+					weight = weight.saturating_add(T::DbWeight::get().reads(1));
+
+					for raw_msg in request.1.socket_messages {
+						weight = insert_txid(raw_msg, request.0, weight);
+					}
+				}
+				current.put::<Pallet<T>>();
+				log!(info, "btc-socket-queue translated socket messages count: {:?} ✅", count);
+				log!(info, "btc-socket-queue storage migration passes v2 update ✅");
+				weight = weight.saturating_add(T::DbWeight::get().writes(1));
+			} else {
+				log!(warn, "Skipping btc-socket-queue storage v2 💤");
+			}
+			weight
+		}
+	}
+}
+
 pub mod init_v1 {
 	use super::*;
 	use core::marker::PhantomData;

--- a/pallets/btc-socket-queue/src/pallet/mod.rs
+++ b/pallets/btc-socket-queue/src/pallet/mod.rs
@@ -25,7 +25,7 @@ use sp_std::{vec, vec::Vec};
 pub mod pallet {
 	use super::*;
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -208,9 +208,13 @@ pub mod pallet {
 		StorageDoubleMap<_, Twox64Concat, H256, Twox64Concat, U256, H256>;
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
+	where
+		T::AccountId: Into<H160>,
+		H160: Into<T::AccountId>,
+	{
 		fn on_runtime_upgrade() -> Weight {
-			migrations::init_v1::InitV1::<T>::on_runtime_upgrade()
+			migrations::v2::V2::<T>::on_runtime_upgrade()
 		}
 	}
 

--- a/pallets/btc-socket-queue/src/pallet/mod.rs
+++ b/pallets/btc-socket-queue/src/pallet/mod.rs
@@ -148,8 +148,10 @@ pub mod pallet {
 	#[pallet::getter(fn socket_messages)]
 	/// The submitted `SocketMessage` instances.
 	/// key: Request sequence ID.
-	/// value: The socket message in bytes.
-	pub type SocketMessages<T: Config> = StorageMap<_, Twox64Concat, U256, SocketMessage>;
+	/// value:
+	/// 	0. The PSBT txid that contains the socket message.
+	/// 	1. The socket message in bytes.
+	pub type SocketMessages<T: Config> = StorageMap<_, Twox64Concat, U256, (H256, SocketMessage)>;
 
 	#[pallet::storage]
 	#[pallet::unbounded]
@@ -316,7 +318,7 @@ pub mod pallet {
 				Self::try_psbt_output_verification(&psbt_obj, outputs)?;
 
 			for msg in deserialized_msgs {
-				<SocketMessages<T>>::insert(msg.req_id.sequence, msg);
+				<SocketMessages<T>>::insert(msg.req_id.sequence, (txid, msg));
 			}
 			<PendingRequests<T>>::insert(
 				&txid,

--- a/precompiles/btc-registration-pool/src/interface.sol
+++ b/precompiles/btc-registration-pool/src/interface.sol
@@ -41,7 +41,9 @@ interface BtcRegistrationPool {
     /// @dev Returns the current registration pool
     /// @custom:selector cc65f61a
     /// @return The list of the current registration pool (0: Bifrost addresses, 1: refund addresses, 2: vault addresses)
-    function registration_pool(uint32 pool_round)
+    function registration_pool(
+        uint32 pool_round
+    )
         external
         view
         returns (address[] memory, string[] memory, string[] memory);
@@ -49,32 +51,38 @@ interface BtcRegistrationPool {
     /// @dev Returns the current pending registrations
     /// @custom:selector 752507ef
     /// @return The list of the current pending registrations (0: Bifrost addresses, 1: refund addresses)
-    function pending_registrations(uint32 pool_round)
-        external
-        view
-        returns (address[] memory, string[] memory);
+    function pending_registrations(
+        uint32 pool_round
+    ) external view returns (address[] memory, string[] memory);
 
     /// @dev Returns the current bonded vault addresses
     /// @custom:selector fd26a335
     /// @return The list of the current bonded vault addresses
-    function vault_addresses(uint32 pool_round) external view returns (string[] memory);
+    function vault_addresses(
+        uint32 pool_round
+    ) external view returns (string[] memory);
 
     /// @dev Returns the current bonded descriptors
     /// @custom:selector f8f5c229
     /// @return The list of the current bonded descriptors
-    function descriptors(uint32 pool_round) external view returns (string[] memory);
+    function descriptors(
+        uint32 pool_round
+    ) external view returns (string[] memory);
 
     /// @dev Returns the current bonded refund addresses
     /// @custom:selector 4e9b6a3b
     /// @return The list of the current bonded refund addresses
-    function refund_addresses(uint32 pool_round) external view returns (string[] memory);
+    function refund_addresses(
+        uint32 pool_round
+    ) external view returns (string[] memory);
 
     /// @dev Returns the bonded vault address mapped to the Bifrost address
     /// @custom:selector 414628e3
     /// @param user_bfc_address the address that we want to check
     /// @return A Bitcoin vault address
     function vault_address(
-        address user_bfc_address, uint32 pool_round
+        address user_bfc_address,
+        uint32 pool_round
     ) external view returns (string memory);
 
     /// @dev Returns the bonded refund address mapped to the Bifrost address
@@ -82,7 +90,8 @@ interface BtcRegistrationPool {
     /// @param user_bfc_address the address that we want to check
     /// @return A Bitcoin refund address
     function refund_address(
-        address user_bfc_address, uint32 pool_round
+        address user_bfc_address,
+        uint32 pool_round
     ) external view returns (string memory);
 
     /// @dev Returns the bonded user address mapped to the given vault address
@@ -90,7 +99,8 @@ interface BtcRegistrationPool {
     /// @param vault_address the vault address
     /// @return The users Bifrost address
     function user_address(
-        string memory vault_address, uint32 pool_round
+        string memory vault_address,
+        uint32 pool_round
     ) external view returns (address);
 
     /// @dev Returns the bonded descriptor(string) mapped to the given vault address
@@ -98,11 +108,17 @@ interface BtcRegistrationPool {
     /// @param vault_address the vault or refund address
     /// @return The descriptor (in string)
     function descriptor(
-        string memory vault_address, uint32 pool_round
+        string memory vault_address,
+        uint32 pool_round
     ) external view returns (string memory);
 
     /// @dev Join the registration pool and request a Bitcoin vault address.
     /// @custom:selector f65d6a74
     /// @param refund_address The Bitcoin refund address
     function request_vault(string memory refund_address) external;
+
+    /// @dev (Re-)set the user's refund address.
+    /// @custom:selector
+    /// @param refund_address The Bitcoin refund address
+    function set_refund(string memory refund_address) external;
 }

--- a/precompiles/btc-registration-pool/src/interface.sol
+++ b/precompiles/btc-registration-pool/src/interface.sol
@@ -118,7 +118,7 @@ interface BtcRegistrationPool {
     function request_vault(string memory refund_address) external;
 
     /// @dev (Re-)set the user's refund address.
-    /// @custom:selector
+    /// @custom:selector 7d538c00
     /// @param refund_address The Bitcoin refund address
     function set_refund(string memory refund_address) external;
 }

--- a/precompiles/btc-socket-queue/src/interface.sol
+++ b/precompiles/btc-socket-queue/src/interface.sol
@@ -61,7 +61,7 @@ interface BtcSocketQueue {
     /// @dev Returns the PSBT txid that contains the given socket message.
     /// @custom:selector 2bce5722
     /// @return The PSBT txid
-    function socket_message_tx(
+    function sequence_to_tx_hash(
         uint256 sequence
     ) external view returns (bytes32);
 

--- a/precompiles/btc-socket-queue/src/interface.sol
+++ b/precompiles/btc-socket-queue/src/interface.sol
@@ -58,6 +58,13 @@ interface BtcSocketQueue {
     /// @return The list of the socket messages used for the given transaction
     function outbound_tx(bytes32 txid) external view returns (bytes[] memory);
 
+    /// @dev Returns the PSBT txid that contains the given socket message.
+    /// @custom:selector 2bce5722
+    /// @return The PSBT txid
+    function socket_message_tx(
+        uint256 sequence
+    ) external view returns (bytes32);
+
     /// @dev Returns the bonded PSBT transaction hash of the given output information.
     /// @custom:selector abbfb5ed
     /// @return The bonded PSBT transaction hash

--- a/precompiles/btc-socket-queue/src/interface.sol
+++ b/precompiles/btc-socket-queue/src/interface.sol
@@ -59,9 +59,9 @@ interface BtcSocketQueue {
     function outbound_tx(bytes32 txid) external view returns (bytes[] memory);
 
     /// @dev Returns the PSBT txid that contains the given socket message.
-    /// @custom:selector 2bce5722
+    /// @custom:selector 821e058c
     /// @return The PSBT txid
-    function sequence_to_tx_hash(
+    function sequence_to_tx_id(
         uint256 sequence
     ) external view returns (bytes32);
 

--- a/precompiles/btc-socket-queue/src/lib.rs
+++ b/precompiles/btc-socket-queue/src/lib.rs
@@ -143,10 +143,10 @@ where
 		})
 	}
 
-	#[precompile::public("sequenceToTxHash(uint256)")]
-	#[precompile::public("sequence_to_tx_hash(uint256)")]
+	#[precompile::public("sequenceToTxId(uint256)")]
+	#[precompile::public("sequence_to_tx_id(uint256)")]
 	#[precompile::view]
-	fn sequence_to_tx_hash(handle: &mut impl PrecompileHandle, sequence: U256) -> EvmResult<H256> {
+	fn sequence_to_tx_id(handle: &mut impl PrecompileHandle, sequence: U256) -> EvmResult<H256> {
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
 		Ok(match BtcSocketQueueOf::<Runtime>::socket_messages(sequence) {

--- a/precompiles/btc-socket-queue/src/lib.rs
+++ b/precompiles/btc-socket-queue/src/lib.rs
@@ -143,6 +143,18 @@ where
 		})
 	}
 
+	#[precompile::public("socketMessageTx(uint256)")]
+	#[precompile::public("socket_message_tx(uint256)")]
+	#[precompile::view]
+	fn socket_message_tx(handle: &mut impl PrecompileHandle, sequence: U256) -> EvmResult<H256> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		Ok(match BtcSocketQueueOf::<Runtime>::socket_messages(sequence) {
+			Some((txid, _)) => txid,
+			None => H256::zero(),
+		})
+	}
+
 	#[precompile::public("rollbackOutput(bytes32,uint256)")]
 	#[precompile::public("rollback_output(bytes32,uint256)")]
 	#[precompile::view]

--- a/precompiles/btc-socket-queue/src/lib.rs
+++ b/precompiles/btc-socket-queue/src/lib.rs
@@ -143,10 +143,10 @@ where
 		})
 	}
 
-	#[precompile::public("socketMessageTx(uint256)")]
-	#[precompile::public("socket_message_tx(uint256)")]
+	#[precompile::public("sequenceToTxHash(uint256)")]
+	#[precompile::public("sequence_to_tx_hash(uint256)")]
 	#[precompile::view]
-	fn socket_message_tx(handle: &mut impl PrecompileHandle, sequence: U256) -> EvmResult<H256> {
+	fn sequence_to_tx_hash(handle: &mut impl PrecompileHandle, sequence: U256) -> EvmResult<H256> {
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
 		Ok(match BtcSocketQueueOf::<Runtime>::socket_messages(sequence) {

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -144,7 +144,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 350,
+	spec_version: 352,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.


### PR DESCRIPTION
## Description

- `SocketMessages` 스토리지 구조 업데이트 → 스토리지 마이그레이션 포함 (v2)
  - 튜플로 변경
  - 첫번째 인자: 해당 메시지가 포함된 PSBT의 txid
  - 두번째 인자: 해당 메시지의 바이트 값
- `set_refund()` 함수 추가
- `sequence_to_tx_id()` 함수 추가

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
