### PR TITLE
NODE-126, fix: consider address check after vault generation

### DIFF
--- a/pallets/btc-registration-pool/src/pallet/impls.rs
+++ b/pallets/btc-registration-pool/src/pallet/impls.rs
@@ -134,8 +134,7 @@ impl<T: Config> Pallet<T> {
 
 		// check if address is already in used as a refund address
 		if <BondedRefund<T>>::contains_key(current_round, &vault_address) {
-			// clear stored pubkeys
-			vault.clear_pub_keys();
+			return Err(Error::<T>::AddressAlreadyRegistered.into());
 		} else {
 			vault.set_address(vault_address.clone());
 			vault.set_descriptor(descriptor.clone());
@@ -149,7 +148,6 @@ impl<T: Config> Pallet<T> {
 				vault_address,
 			});
 		}
-
 		Ok(())
 	}
 

--- a/pallets/btc-registration-pool/src/pallet/impls.rs
+++ b/pallets/btc-registration-pool/src/pallet/impls.rs
@@ -1,6 +1,6 @@
 use bp_multi_sig::{
 	traits::PoolManager, Address, AddressState, Descriptor, Error as KeyError, MigrationSequence,
-	Network, PublicKey, UnboundedBytes,
+	MultiSigAccount, Network, PublicKey, UnboundedBytes,
 };
 use frame_support::traits::SortedMembers;
 use scale_info::prelude::string::{String, ToString};
@@ -118,6 +118,39 @@ impl<T: Config> Pallet<T> {
 			.map_err(|_| Error::<T>::InvalidBitcoinAddress)?,
 			desc.to_string().as_bytes().to_vec(),
 		))
+	}
+
+	/// Tries to generate a vault address with the given public keys.
+	/// If the generated address is already used as a refund address, the stored public keys will be cleared.
+	/// If not, the address will be bonded successfully.
+	pub fn try_bond_vault_address(
+		vault: &mut MultiSigAccount<T::AccountId>,
+		refund_address: &BoundedBitcoinAddress,
+		who: T::AccountId,
+		current_round: u32,
+	) -> Result<(), DispatchError> {
+		// generate vault address
+		let (vault_address, descriptor) = Self::generate_vault_address(vault.pub_keys())?;
+
+		// check if address is already in used as a refund address
+		if <BondedRefund<T>>::contains_key(current_round, &vault_address) {
+			// clear stored pubkeys
+			vault.clear_pub_keys();
+		} else {
+			vault.set_address(vault_address.clone());
+			vault.set_descriptor(descriptor.clone());
+
+			<BondedVault<T>>::insert(current_round, &vault_address, who.clone());
+			<BondedDescriptor<T>>::insert(current_round, &vault_address, descriptor);
+
+			Self::deposit_event(Event::VaultGenerated {
+				who: who.clone(),
+				refund_address: refund_address.clone(),
+				vault_address,
+			});
+		}
+
+		Ok(())
 	}
 
 	/// Check if the given address is valid on the target Bitcoin network. Then returns the checked address.

--- a/pallets/btc-registration-pool/src/pallet/mod.rs
+++ b/pallets/btc-registration-pool/src/pallet/mod.rs
@@ -438,8 +438,6 @@ pub mod pallet {
 					current_round,
 				)?;
 			}
-
-			// we still bond public keys to make sure it is not used again
 			<BondedPubKey<T>>::insert(current_round, &pub_key, who.clone());
 			<RegistrationPool<T>>::insert(current_round, &who, relay_target);
 

--- a/primitives/multi-sig/src/lib.rs
+++ b/primitives/multi-sig/src/lib.rs
@@ -115,6 +115,10 @@ impl<AccountId: PartialEq + Clone + Ord> MultiSigAccount<AccountId> {
 	pub fn pub_keys(&self) -> Vec<Public> {
 		self.pub_keys.values().cloned().collect()
 	}
+
+	pub fn clear_pub_keys(&mut self) {
+		self.pub_keys = BoundedBTreeMap::new();
+	}
 }
 
 #[derive(Decode, Encode, TypeInfo, MaxEncodedLen)]

--- a/primitives/multi-sig/src/lib.rs
+++ b/primitives/multi-sig/src/lib.rs
@@ -115,10 +115,6 @@ impl<AccountId: PartialEq + Clone + Ord> MultiSigAccount<AccountId> {
 	pub fn pub_keys(&self) -> Vec<Public> {
 		self.pub_keys.values().cloned().collect()
 	}
-
-	pub fn clear_pub_keys(&mut self) {
-		self.pub_keys = BoundedBTreeMap::new();
-	}
 }
 
 #[derive(Decode, Encode, TypeInfo, MaxEncodedLen)]


### PR DESCRIPTION
## Description

- `BondedRefund`가 생성된 vault 주소를 포함하고 있는지 검사한다.
- 만약 존재한다면, 에러 반환하도록 수정

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
