### PR TITLE
NODE-128, fix: add `SetExecutiveMembers` to `MigrationSequence`

### DIFF
--- a/pallets/btc-registration-pool/src/pallet/mod.rs
+++ b/pallets/btc-registration-pool/src/pallet/mod.rs
@@ -481,7 +481,7 @@ pub mod pallet {
 				MigrationSequence::PrepareNextSystemVault => {
 					target_round = Self::current_round() + 1;
 				},
-				MigrationSequence::UTXOTransfer => {
+				MigrationSequence::SetExecutiveMembers | MigrationSequence::UTXOTransfer => {
 					return Err(Error::<T>::UnderMaintenance)?;
 				},
 			}
@@ -653,6 +653,9 @@ pub mod pallet {
 			match Self::service_state() {
 				MigrationSequence::Normal => {
 					Self::deposit_event(Event::MigrationStarted);
+					<ServiceState<T>>::put(MigrationSequence::SetExecutiveMembers);
+				},
+				MigrationSequence::SetExecutiveMembers => {
 					Self::request_system_vault(origin, true)?;
 					<ServiceState<T>>::put(MigrationSequence::PrepareNextSystemVault);
 				},

--- a/pallets/btc-registration-pool/src/pallet/mod.rs
+++ b/pallets/btc-registration-pool/src/pallet/mod.rs
@@ -647,6 +647,12 @@ pub mod pallet {
 
 		#[pallet::call_index(7)]
 		#[pallet::weight(<T as Config>::WeightInfo::default())]
+		/// Initiates and control the current state of the vault migration.
+		/// Every specific calls will be blocked (except submitting a public key for the next system vault)
+		/// until the migration successfully ends.
+		///
+		/// # Sequence Order
+		/// * `Normal` → `SetExecutiveMembers` → `PrepareNextSystemVault` → `UTXOTransfer` → `Normal`
 		pub fn migration_control(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			ensure_root(origin.clone())?;
 

--- a/primitives/multi-sig/src/lib.rs
+++ b/primitives/multi-sig/src/lib.rs
@@ -145,6 +145,8 @@ pub enum MigrationSequence {
 	/// Normal sequence.
 	#[default]
 	Normal,
+	/// Progress relay executive member update (if required).
+	SetExecutiveMembers,
 	/// Prepare next system vault.
 	PrepareNextSystemVault,
 	/// Wait till all UTXOs transferred to the new system vault.

--- a/primitives/multi-sig/src/lib.rs
+++ b/primitives/multi-sig/src/lib.rs
@@ -126,7 +126,6 @@ pub enum AddressState {
 	Generated(BoundedBitcoinAddress),
 }
 
-/// Sequence of migrating registration pool.
 #[derive(
 	Eq,
 	PartialEq,
@@ -141,6 +140,7 @@ pub enum AddressState {
 	MaxEncodedLen,
 	Default,
 )]
+/// Sequence of migrating registration pool.
 pub enum MigrationSequence {
 	/// Normal sequence.
 	#[default]


### PR DESCRIPTION
## Description

- Vault migration 시작 시, Relay executives의 구성원 업데이트 없이 신규 system vault 생성을 방지 하기 위해 `PrepareNextSystemVault` 단계 앞에 `SetExecutiveMembers` 추가

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
