### PR TITLE
NODE-129, fix: remove hard-coded index usage

### DIFF
--- a/pallets/btc-socket-queue/src/pallet/mod.rs
+++ b/pallets/btc-socket-queue/src/pallet/mod.rs
@@ -467,7 +467,7 @@ pub mod pallet {
 				T::RegistrationPool::get_refund_address(&who).ok_or(Error::<T>::UserDNE)?,
 			)?;
 
-			// the request must not exist on-chain
+			// the request must not exist on-chain (=BitcoinSocket contract)
 			let hash_key = Self::generate_hash_key(rollback_txid, vout, who.clone(), amount);
 			let tx_info = Self::try_get_tx_info(hash_key)?;
 			ensure!(tx_info.to.is_zero(), Error::<T>::RequestAlreadyExists);
@@ -484,9 +484,11 @@ pub mod pallet {
 
 			for output in outputs {
 				let to =
-					Self::try_convert_to_address_from_script(outputs[0].script_pubkey.as_script())?;
+					Self::try_convert_to_address_from_script(output.script_pubkey.as_script())?;
 
 				if to == system_vault {
+					// if change exsits, the psbt must contain exactly two outputs.
+					ensure!(outputs.len() == 2, Error::<T>::InvalidPsbt);
 					continue;
 				}
 				if to == refund {
@@ -498,6 +500,7 @@ pub mod pallet {
 					);
 					continue;
 				}
+				// addresses that are not either system vault or refund will be rejected.
 				return Err(Error::<T>::InvalidPsbt.into());
 			}
 


### PR DESCRIPTION
## Description

- 하드코딩된 인덱스 사용 수정
- System vault로 향하는 output 존재 시, output 길이 검사 로직 추가

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
