### PR TITLE
NODE-137, fix: add missing #[precompile::view] macro

### DIFF
--- a/precompiles/btc-registration-pool/src/lib.rs
+++ b/precompiles/btc-registration-pool/src/lib.rs
@@ -129,6 +129,7 @@ where
 
 	#[precompile::public("pendingRegistrations(uint32)")]
 	#[precompile::public("pending_registrations(uint32)")]
+	#[precompile::view]
 	fn pending_registrations(
 		handle: &mut impl PrecompileHandle,
 		pool_round: PoolRound,


### PR DESCRIPTION
## Description

- add missing `#[precompile::view]` macro

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
