### PR TITLE
NODE-138, fix: use `ensure_root()` and remove `SetOrigin`

### DIFF
--- a/pallets/btc-socket-queue/src/pallet/mod.rs
+++ b/pallets/btc-socket-queue/src/pallet/mod.rs
@@ -37,8 +37,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config + pallet_evm::Config {
 		/// Overarching event type
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-		/// Required origin for setting or resetting the configuration.
-		type SetOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 		/// The signature signed by the issuer.
 		type Signature: Verify<Signer = Self::Signer> + Encode + Decode + Parameter;
 		/// The signer of the message.
@@ -444,7 +442,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			msg: RollbackPsbtMessage<T::AccountId>,
 		) -> DispatchResultWithPostInfo {
-			T::SetOrigin::ensure_origin(origin)?;
+			ensure_root(origin)?;
 
 			let RollbackPsbtMessage { who, txid: rollback_txid, vout, amount, unsigned_psbt } = msg;
 

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -970,7 +970,6 @@ impl pallet_base_fee::Config for Runtime {
 
 impl pallet_btc_socket_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type SetOrigin = MoreThanTwoThirdsRelayExecutives;
 	type Signature = EthereumSignature;
 	type Signer = EthereumSigner;
 	type Executives = RelayExecutiveMembership;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -976,7 +976,6 @@ impl pallet_base_fee::Config for Runtime {
 
 impl pallet_btc_socket_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type SetOrigin = MoreThanTwoThirdsRelayExecutives;
 	type Signature = EthereumSignature;
 	type Signer = EthereumSigner;
 	type Executives = RelayExecutiveMembership;


### PR DESCRIPTION
## Description

- use `ensure_root()` and remove `SetOrigin`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
