### PR TITLE
NODE-140, fix: `btc-socket-queue` should be empty before pool migration

### DIFF
--- a/pallets/btc-registration-pool/src/pallet/mod.rs
+++ b/pallets/btc-registration-pool/src/pallet/mod.rs
@@ -11,7 +11,9 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 
-use bp_multi_sig::{MigrationSequence, Network, Public, PublicKey, UnboundedBytes};
+use bp_multi_sig::{
+	traits::SocketQueueManager, MigrationSequence, Network, Public, PublicKey, UnboundedBytes,
+};
 use sp_core::H160;
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
@@ -43,6 +45,8 @@ pub mod pallet {
 			+ MaxEncodedLen;
 		/// The relay executive members.
 		type Executives: SortedMembers<Self::AccountId>;
+		/// Interface of Bitcoin Socket Queue pallet.
+		type SocketQueue: SocketQueueManager<Self::AccountId>;
 		/// The minimum required number of signatures to send a transaction with the vault account. (in percentage)
 		#[pallet::constant]
 		type DefaultMultiSigRatio: Get<Percent>;
@@ -81,6 +85,8 @@ pub mod pallet {
 		OutOfRange,
 		/// Service is under maintenance mode.
 		UnderMaintenance,
+		/// SocketQueue is not ready for migration.
+		SocketQueueNotReady,
 		/// Do not control migration sequence in this state.
 		DoNotInterceptMigration,
 		/// Presubmission does not exist.
@@ -652,6 +658,7 @@ pub mod pallet {
 
 			match Self::service_state() {
 				MigrationSequence::Normal => {
+					ensure!(T::SocketQueue::is_ready_for_migrate(), Error::<T>::SocketQueueNotReady);
 					Self::deposit_event(Event::MigrationStarted);
 					<ServiceState<T>>::put(MigrationSequence::SetExecutiveMembers);
 				},

--- a/primitives/multi-sig/src/traits.rs
+++ b/primitives/multi-sig/src/traits.rs
@@ -24,3 +24,8 @@ pub trait PoolManager<AccountId> {
 	/// Get the current pool round.
 	fn get_current_round() -> u32;
 }
+
+pub trait SocketQueueManager<AccountId> {
+	/// Check if the system is ready for migrate.
+	fn is_ready_for_migrate() -> bool;
+}

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -992,6 +992,7 @@ impl pallet_btc_registration_pool::Config for Runtime {
 	type Signature = EthereumSignature;
 	type Signer = EthereumSigner;
 	type Executives = RelayExecutiveMembership;
+	type SocketQueue = BtcSocketQueue;
 	type DefaultMultiSigRatio = DefaultMultiSigRatio;
 	type BitcoinChainId = BitcoinChainId;
 	type BitcoinNetwork = BitcoinNetwork;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -998,6 +998,7 @@ impl pallet_btc_registration_pool::Config for Runtime {
 	type Signature = EthereumSignature;
 	type Signer = EthereumSigner;
 	type Executives = RelayExecutiveMembership;
+	type SocketQueue = BtcSocketQueue;
 	type DefaultMultiSigRatio = DefaultMultiSigRatio;
 	type BitcoinChainId = BitcoinChainId;
 	type BitcoinNetwork = BitcoinNetwork;


### PR DESCRIPTION
## Description

* Registration pool migration could start only when socket queue is empty

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
