### PR TITLE
NODE-158, fix: update runtime api to stable version

### DIFF
--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -323,7 +323,7 @@ macro_rules! impl_common_runtime_apis {
 						// max_priority_fee_per_gas: 32
 						// max_fee_per_gas: 32
 						// gas_limit: 32
-						// action: 21 (enum varianrt + call address)
+						// action: 21 (enum variant + call address)
 						// value: 32
 						// access_list: 1 (empty vec size)
 						// 65 bytes signature

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -302,6 +302,8 @@ macro_rules! impl_common_runtime_apis {
 					estimate: bool,
 					access_list: Option<Vec<(H160, Vec<H256>)>>,
 				) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
+					use pallet_evm::GasWeightMapping as _;
+
 					let config = if estimate {
 						let mut config = <Runtime as pallet_evm::Config>::config().clone();
 						config.estimate = true;
@@ -310,20 +312,44 @@ macro_rules! impl_common_runtime_apis {
 						None
 					};
 
-					let gas_limit = gas_limit.min(u64::MAX.into());
-					let transaction_data = TransactionData::new(
-						TransactionAction::Call(to),
-						data.clone(),
-						nonce.unwrap_or_default(),
-						gas_limit,
-						None,
-						max_fee_per_gas,
-						max_priority_fee_per_gas,
-						value,
-						Some(<Runtime as pallet_evm::Config>::ChainId::get()),
-						access_list.clone().unwrap_or_default(),
-					);
-					let (weight_limit, proof_size_base_cost) = pallet_ethereum::Pallet::<Runtime>::transaction_weight(&transaction_data);
+					// Estimated encoded transaction size must be based on the heaviest transaction
+					// type (EIP1559Transaction) to be compatible with all transaction types.
+					let mut estimated_transaction_len = data.len() +
+						// pallet ethereum index: 1
+						// transact call index: 1
+						// Transaction enum variant: 1
+						// chain_id 8 bytes
+						// nonce: 32
+						// max_priority_fee_per_gas: 32
+						// max_fee_per_gas: 32
+						// gas_limit: 32
+						// action: 21 (enum varianrt + call address)
+						// value: 32
+						// access_list: 1 (empty vec size)
+						// 65 bytes signature
+						258;
+
+					if access_list.is_some() {
+						estimated_transaction_len += access_list.encoded_size();
+					}
+
+					let gas_limit = if gas_limit > U256::from(u64::MAX) {
+						u64::MAX
+					} else {
+						gas_limit.low_u64()
+					};
+					let without_base_extrinsic_weight = true;
+
+					let (weight_limit, proof_size_base_cost) =
+						match <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
+							gas_limit,
+							without_base_extrinsic_weight
+						) {
+							weight_limit if weight_limit.proof_size() > 0 => {
+								(Some(weight_limit), Some(estimated_transaction_len as u64))
+							}
+							_ => (None, None),
+						};
 
 					<Runtime as pallet_evm::Config>::Runner::call(
 						from,
@@ -353,6 +379,8 @@ macro_rules! impl_common_runtime_apis {
 					estimate: bool,
 					access_list: Option<Vec<(H160, Vec<H256>)>>,
 				) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
+					use pallet_evm::GasWeightMapping as _;
+
 					let config = if estimate {
 						let mut config = <Runtime as pallet_evm::Config>::config().clone();
 						config.estimate = true;
@@ -361,19 +389,43 @@ macro_rules! impl_common_runtime_apis {
 						None
 					};
 
-					let transaction_data = TransactionData::new(
-						TransactionAction::Create,
-						data.clone(),
-						nonce.unwrap_or_default(),
-						gas_limit,
-						None,
-						max_fee_per_gas,
-						max_priority_fee_per_gas,
-						value,
-						Some(<Runtime as pallet_evm::Config>::ChainId::get()),
-						access_list.clone().unwrap_or_default(),
-					);
-					let (weight_limit, proof_size_base_cost) = pallet_ethereum::Pallet::<Runtime>::transaction_weight(&transaction_data);
+					let mut estimated_transaction_len = data.len() +
+						// from: 20
+						// value: 32
+						// gas_limit: 32
+						// nonce: 32
+						// 1 byte transaction action variant
+						// chain id 8 bytes
+						// 65 bytes signature
+						190;
+
+					if max_fee_per_gas.is_some() {
+						estimated_transaction_len += 32;
+					}
+					if max_priority_fee_per_gas.is_some() {
+						estimated_transaction_len += 32;
+					}
+					if access_list.is_some() {
+						estimated_transaction_len += access_list.encoded_size();
+					}
+
+					let gas_limit = if gas_limit > U256::from(u64::MAX) {
+						u64::MAX
+					} else {
+						gas_limit.low_u64()
+					};
+					let without_base_extrinsic_weight = true;
+
+					let (weight_limit, proof_size_base_cost) =
+						match <Runtime as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
+							gas_limit,
+							without_base_extrinsic_weight
+						) {
+							weight_limit if weight_limit.proof_size() > 0 => {
+								(Some(weight_limit), Some(estimated_transaction_len as u64))
+							}
+							_ => (None, None),
+						};
 
 					<Runtime as pallet_evm::Config>::Runner::create(
 						from,

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -46,7 +46,6 @@ pub use pallet_balances::{Call as BalancesCall, NegativeImbalance};
 pub use pallet_bfc_staking::{InflationInfo, Range};
 use pallet_ethereum::{
 	Call::transact, EthereumBlockHashMapping, PostLogContent, Transaction as EthereumTransaction,
-	TransactionAction, TransactionData,
 };
 use pallet_evm::{
 	Account as EVMAccount, EVMCurrencyAdapter, EnsureAddressNever, EnsureAddressRoot,

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 2027,
+	spec_version: 2028,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -44,7 +44,6 @@ pub use pallet_balances::{Call as BalancesCall, NegativeImbalance};
 pub use pallet_bfc_staking::{InflationInfo, Range};
 use pallet_ethereum::{
 	Call::transact, EthereumBlockHashMapping, PostLogContent, Transaction as EthereumTransaction,
-	TransactionAction, TransactionData,
 };
 use pallet_evm::{
 	Account as EVMAccount, EVMCurrencyAdapter, EnsureAddressNever, EnsureAddressRoot,

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -152,7 +152,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 477,
+	spec_version: 478,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -44,7 +44,6 @@ pub use pallet_balances::{Call as BalancesCall, NegativeImbalance};
 pub use pallet_bfc_staking::{InflationInfo, Range};
 use pallet_ethereum::{
 	Call::transact, EthereumBlockHashMapping, PostLogContent, Transaction as EthereumTransaction,
-	TransactionAction, TransactionData,
 };
 use pallet_evm::{
 	Account as EVMAccount, EVMCurrencyAdapter, EnsureAddressNever, EnsureAddressRoot,


### PR DESCRIPTION
## Description

- `call()` & `create()` runtime api stable한 버전으로 수정 ([ref.](https://github.com/polkadot-evm/frontier/blob/stable2407/template/runtime/src/lib.rs#L786-L864))

## Ref.
- https://github.com/moonbeam-foundation/moonbeam/pull/2440

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
