### PR TITLE
fix: Reject non-canonical SocketMessage bytes in verify_socket_message

### DIFF
--- a/pallets/btc-socket-queue/src/pallet/impls.rs
+++ b/pallets/btc-socket-queue/src/pallet/impls.rs
@@ -42,9 +42,13 @@ where
 	H160: Into<T::AccountId>,
 {
 	fn verify_socket_message(msg: &UnboundedBytes) -> Result<(), DispatchError> {
+		let original_msg = msg.clone();
 		// the bytes should be a valid socket message
-		let msg =
-			SocketMessage::try_from(msg.clone()).map_err(|_| Error::<T>::InvalidSocketMessage)?;
+		let msg = SocketMessage::try_from(original_msg.clone())
+			.map_err(|_| Error::<T>::InvalidSocketMessage)?;
+		if msg.encode() != original_msg {
+			return Err(Error::<T>::InvalidSocketMessage.into());
+		}
 		// the socket message should be valid onchain
 		let msg_hash =
 			Self::hash_bytes(&UserRequest::new(msg.ins_code.clone(), msg.params.clone()).encode());
@@ -516,8 +520,7 @@ where
 					let system_vault = T::RegistrationPool::get_system_vault(
 						T::RegistrationPool::get_current_round(),
 					)?;
-					let system_vault =
-						Self::try_convert_to_address_from_vec(system_vault).ok()?;
+					let system_vault = Self::try_convert_to_address_from_vec(system_vault).ok()?;
 					output.push(TxOut {
 						value: Amount::from_sat(change_amount),
 						script_pubkey: system_vault.script_pubkey(),


### PR DESCRIPTION
## Description

- Reject non-canonical SocketMessage bytes in verify_socket_message

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
