### PR TITLE
blaze, relay-queue update

### DIFF
--- a/pallets/blaze/src/lib.rs
+++ b/pallets/blaze/src/lib.rs
@@ -32,6 +32,9 @@ pub const MAX_SOCKET_MESSAGES_PER_SUBMISSION: usize = 10;
 /// Maximum number of UTXOs allowed per `submit_utxos` submission.
 pub const MAX_UTXOS_PER_SUBMISSION: usize = 50;
 
+/// Maximum number of unconfirmed UTXOs a single relayer may have pending at any time.
+pub const MAX_UNCONFIRMED_UTXOS_PER_RELAYER: u32 = 100;
+
 // syntactic sugar for logging.
 #[macro_export]
 macro_rules! log {

--- a/pallets/blaze/src/lib.rs
+++ b/pallets/blaze/src/lib.rs
@@ -26,6 +26,9 @@ use sp_std::vec::Vec;
 
 pub(crate) const LOG_TARGET: &'static str = "runtime::blaze";
 
+/// Maximum number of socket messages allowed per `submit_outbound_requests` submission.
+pub const MAX_SOCKET_MESSAGES_PER_SUBMISSION: usize = 10;
+
 // syntactic sugar for logging.
 #[macro_export]
 macro_rules! log {

--- a/pallets/blaze/src/lib.rs
+++ b/pallets/blaze/src/lib.rs
@@ -29,6 +29,9 @@ pub(crate) const LOG_TARGET: &'static str = "runtime::blaze";
 /// Maximum number of socket messages allowed per `submit_outbound_requests` submission.
 pub const MAX_SOCKET_MESSAGES_PER_SUBMISSION: usize = 10;
 
+/// Maximum number of UTXOs allowed per `submit_utxos` submission.
+pub const MAX_UTXOS_PER_SUBMISSION: usize = 50;
+
 // syntactic sugar for logging.
 #[macro_export]
 macro_rules! log {

--- a/pallets/blaze/src/mock.rs
+++ b/pallets/blaze/src/mock.rs
@@ -109,6 +109,10 @@ impl SocketQueueManager<AccountId> for MockSocketQueue {
 		Ok(())
 	}
 
+	fn verify_legacy_authority(_: &AccountId) -> Result<(), TransactionValidityError> {
+		Ok(())
+	}
+
 	fn replace_authority(_: &AccountId, _: &AccountId) {}
 
 	fn get_max_fee_rate() -> u64 {
@@ -122,6 +126,10 @@ impl SocketQueueManager<AccountId> for MockSocketQueue {
 impl SocketVerifier<AccountId> for MockSocketQueue {
 	fn verify_socket_message(_: &UnboundedBytes) -> Result<(), DispatchError> {
 		Ok(())
+	}
+
+	fn get_max_socket_message_bytes() -> u32 {
+		2 * 1024
 	}
 }
 

--- a/pallets/blaze/src/pallet/impls.rs
+++ b/pallets/blaze/src/pallet/impls.rs
@@ -29,6 +29,12 @@ use sp_std::{fmt::Display, vec, vec::Vec};
 
 impl<T: Config> BlazeManager<T> for Pallet<T> {
 	fn replace_authority(old: &T::AccountId, new: &T::AccountId) {
+		// Migrate unconfirmed UTXO count from old to new authority.
+		let old_count = <UnconfirmedUtxoCount<T>>::take(old);
+		if old_count > 0 {
+			<UnconfirmedUtxoCount<T>>::insert(new, old_count);
+		}
+
 		// Replace authority in unconfirmed UTXOs (still accumulating votes)
 		<Utxos<T>>::iter().for_each(|(hash, mut utxo)| {
 			if utxo.status == UtxoStatus::Unconfirmed && utxo.voters.contains(old) {
@@ -77,6 +83,11 @@ impl<T: Config> BlazeManager<T> for Pallet<T> {
 		let utxos = <Utxos<T>>::iter().collect::<Vec<_>>();
 		for (hash, utxo) in utxos {
 			if utxo.status != UtxoStatus::Used {
+				if utxo.status == UtxoStatus::Unconfirmed {
+					if let Some(submitter) = utxo.voters.first() {
+						<UnconfirmedUtxoCount<T>>::mutate(submitter, |c| *c = c.saturating_sub(1));
+					}
+				}
 				<Utxos<T>>::remove(hash);
 			}
 		}

--- a/pallets/blaze/src/pallet/impls.rs
+++ b/pallets/blaze/src/pallet/impls.rs
@@ -675,6 +675,11 @@ impl<T: Config> Pallet<T> {
 	) -> TransactionValidity {
 		let SocketMessagesSubmission { authority_id, messages } = outbound_request_submission;
 
+		// reject if the number of messages exceeds the per-submission limit.
+		if messages.len() > crate::MAX_SOCKET_MESSAGES_PER_SUBMISSION {
+			return InvalidTransaction::ExhaustsResources.into();
+		}
+
 		// reject if any individual message exceeds the configured size limit.
 		let max_bytes = T::SocketQueue::get_max_socket_message_bytes() as usize;
 		if messages.iter().any(|m| m.len() > max_bytes) {

--- a/pallets/blaze/src/pallet/impls.rs
+++ b/pallets/blaze/src/pallet/impls.rs
@@ -8,6 +8,7 @@ use bp_btc_relay::{
 	traits::{BlazeManager, SocketQueueManager},
 	Hash, Psbt, UnboundedBytes,
 };
+use bp_cccp::traits::SocketVerifier;
 use bp_staking::traits::Authorities;
 use frame_support::{
 	ensure,
@@ -397,9 +398,7 @@ impl<T: Config> Pallet<T> {
 				&& scored.effective_value <= target + change_target
 				&& scored.utxo.input_vbytes <= max_weight
 			{
-				if best_exact
-					.as_ref()
-					.map_or(true, |x| scored.effective_value < x.effective_value)
+				if best_exact.as_ref().map_or(true, |x| scored.effective_value < x.effective_value)
 				{
 					best_exact = Some(scored.clone());
 				}
@@ -473,8 +472,7 @@ impl<T: Config> Pallet<T> {
 			if curr_value >= target {
 				if curr_value < *best_total {
 					*best_total = curr_value;
-					*best_selection =
-						curr_selection.iter().map(|x| x.utxo.clone()).collect();
+					*best_selection = curr_selection.iter().map(|x| x.utxo.clone()).collect();
 				}
 				return;
 			}
@@ -542,9 +540,7 @@ impl<T: Config> Pallet<T> {
 		// A single larger UTXO may be preferable (fewer inputs = smaller tx).
 		if !best_selection.is_empty() {
 			if let Some(ref larger) = lowest_larger {
-				if larger.utxo.input_vbytes <= max_weight
-					&& larger.effective_value <= best_total
-				{
+				if larger.utxo.input_vbytes <= max_weight && larger.effective_value <= best_total {
 					return Some((vec![larger.utxo.clone()], SelectionStrategy::Knapsack));
 				}
 			}
@@ -595,8 +591,13 @@ impl<T: Config> Pallet<T> {
 					.iter()
 					.map(|x| {
 						let utxo_hash = H256::from_slice(
-							keccak_256(&Encode::encode(&(x.txid, x.vout, x.amount, x.address.clone())))
-								.as_ref(),
+							keccak_256(&Encode::encode(&(
+								x.txid,
+								x.vout,
+								x.amount,
+								x.address.clone(),
+							)))
+							.as_ref(),
 						);
 						hex::encode(utxo_hash)
 					})
@@ -673,6 +674,12 @@ impl<T: Config> Pallet<T> {
 		signature: &T::Signature,
 	) -> TransactionValidity {
 		let SocketMessagesSubmission { authority_id, messages } = outbound_request_submission;
+
+		// reject if any individual message exceeds the configured size limit.
+		let max_bytes = T::SocketQueue::get_max_socket_message_bytes() as usize;
+		if messages.iter().any(|m| m.len() > max_bytes) {
+			return InvalidTransaction::ExhaustsResources.into();
+		}
 
 		// verify if the authority is a selected relayer.
 		Self::verify_authority(authority_id)?;

--- a/pallets/blaze/src/pallet/impls.rs
+++ b/pallets/blaze/src/pallet/impls.rs
@@ -579,6 +579,11 @@ impl<T: Config> Pallet<T> {
 	) -> TransactionValidity {
 		let UtxoSubmission { authority_id, utxos } = utxo_submission;
 
+		// reject if the number of UTXOs exceeds the per-submission limit.
+		if utxos.len() > crate::MAX_UTXOS_PER_SUBMISSION {
+			return InvalidTransaction::ExhaustsResources.into();
+		}
+
 		// verify if the authority is a selected relayer.
 		Self::verify_authority(authority_id)?;
 

--- a/pallets/blaze/src/pallet/mod.rs
+++ b/pallets/blaze/src/pallet/mod.rs
@@ -357,7 +357,10 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(4)]
-		#[pallet::weight(<T as Config>::WeightInfo::submit_outbound_requests())]
+		#[pallet::weight(<T as Config>::WeightInfo::submit_outbound_requests(
+			outbound_request_submission.messages.len() as u32,
+			outbound_request_submission.messages.iter().map(|m| m.len() as u32).sum::<u32>(),
+		))]
 		/// Submit Socket messages originated from a Bitcoin outbound request.
 		pub fn submit_outbound_requests(
 			origin: OriginFor<T>,

--- a/pallets/blaze/src/pallet/mod.rs
+++ b/pallets/blaze/src/pallet/mod.rs
@@ -79,6 +79,8 @@ pub mod pallet {
 		NoWritingSameValue,
 		/// The activation status is invalid.
 		InvalidActivationState,
+		/// The relayer has reached the maximum number of unconfirmed UTXOs.
+		UnconfirmedUtxoCapExceeded,
 	}
 
 	#[pallet::event]
@@ -115,6 +117,15 @@ pub mod pallet {
 	/// Key: UTXO hash (keccak256(txid, vout, amount, address))
 	/// Value: UTXO information
 	pub type Utxos<T: Config> = StorageMap<_, Twox64Concat, H256, Utxo<T::AccountId>>;
+
+	#[pallet::storage]
+	/// The number of unconfirmed UTXOs each relayer currently has pending.
+	/// Purpose: To prevent a single relayer from submitting too many UTXOs leading to storage growth.
+	///
+	/// Key: Relayer account id (original submitter)
+	/// Value: Count of unconfirmed UTXOs
+	pub type UnconfirmedUtxoCount<T: Config> =
+		StorageMap<_, Twox64Concat, T::AccountId, u32, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::unbounded]
@@ -223,6 +234,12 @@ pub mod pallet {
 					// check if the utxo majority is reached
 					if u.voters.len() as u32 >= T::Relayers::majority() {
 						u.status = UtxoStatus::Available;
+						// decrement the original submitter's unconfirmed count
+						if let Some(submitter) = u.voters.first() {
+							<UnconfirmedUtxoCount<T>>::mutate(submitter, |c| {
+								*c = c.saturating_sub(1)
+							});
+						}
 					}
 					<Utxos<T>>::insert(&utxo_hash, u.clone());
 					Self::deposit_event(Event::UtxoSubmitted {
@@ -231,6 +248,12 @@ pub mod pallet {
 						status: u.status,
 					});
 				} else {
+					// enforce per-relayer unconfirmed UTXO cap
+					let count = <UnconfirmedUtxoCount<T>>::get(&authority_id);
+					if count >= crate::MAX_UNCONFIRMED_UTXOS_PER_RELAYER {
+						continue;
+					}
+
 					let voters = vec![authority_id.clone()];
 					let input_vbytes = if let Some(input_vbytes) =
 						estimate_finalized_input_size(&descriptor.script_code().unwrap(), None)
@@ -255,6 +278,7 @@ pub mod pallet {
 								.map_err(|_| Error::<T>::OutOfRange)?,
 						},
 					);
+					<UnconfirmedUtxoCount<T>>::insert(&authority_id, count + 1);
 					Self::deposit_event(Event::UtxoSubmitted {
 						authority_id: authority_id.clone(),
 						utxo_hash,

--- a/pallets/blaze/src/pallet/mod.rs
+++ b/pallets/blaze/src/pallet/mod.rs
@@ -79,8 +79,6 @@ pub mod pallet {
 		NoWritingSameValue,
 		/// The activation status is invalid.
 		InvalidActivationState,
-		/// The relayer has reached the maximum number of unconfirmed UTXOs.
-		UnconfirmedUtxoCapExceeded,
 	}
 
 	#[pallet::event]

--- a/pallets/blaze/src/weights.rs
+++ b/pallets/blaze/src/weights.rs
@@ -44,7 +44,7 @@ pub trait WeightInfo {
 	fn submit_utxos() -> Weight;
 	fn broadcast_poll() -> Weight;
 	fn submit_fee_rate() -> Weight;
-	fn submit_outbound_requests() -> Weight;
+	fn submit_outbound_requests(n: u32, total_msg_bytes: u32) -> Weight;
 	fn force_push_utxos() -> Weight;
 	fn remove_outbound_messages() -> Weight;
 }
@@ -114,14 +114,29 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	/// Storage: `Blaze::OutboundPool` (r:1 w:1)
 	/// Proof: `Blaze::OutboundPool` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	fn submit_outbound_requests() -> Weight {
+	/// Storage: `BtcSocketQueue::Authority` (r:1 w:0)
+	/// Proof: `BtcSocketQueue::Authority` (`max_values`: Some(1), `max_size`: Some(20), mode: `MaxEncodedLen`)
+	/// Storage: `BtcSocketQueue::Socket` (r:1 w:0)
+	/// Proof: `BtcSocketQueue::Socket` (`max_values`: Some(1), `max_size`: Some(20), mode: `MaxEncodedLen`)
+	///
+	/// The `n` parameter represents the number of messages in the submission.
+	/// The `total_msg_bytes` parameter represents the total byte length of all messages.
+	/// Each message triggers a `verify_socket_message` call that reads `Authority` and `Socket`,
+	/// plus an EVM contract call for on-chain validation. Message bytes incur additional cost
+	/// from cloning, SCALE decoding/encoding, and keccak256 hashing.
+	fn submit_outbound_requests(n: u32, total_msg_bytes: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `1485`
 		// Minimum execution time: 18_800_000 picoseconds.
 		Weight::from_parts(19_410_000, 0)
+			// base: OutboundPool read + write
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
+			// per message: Authority + Socket reads for verify_socket_message
+			.saturating_add(T::DbWeight::get().reads(2_u64.saturating_mul(n as u64)))
+			// per byte: clone, SCALE decode/encode, keccak256 hashing, storage encoding
+			.saturating_add(Weight::from_parts(1_500_u64.saturating_mul(total_msg_bytes as u64), 0))
 	}
 	/// Storage: `Blaze::IsActivated` (r:1 w:0)
 	/// Proof: `Blaze::IsActivated` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
@@ -221,14 +236,29 @@ impl WeightInfo for () {
 	}
 	/// Storage: `Blaze::OutboundPool` (r:1 w:1)
 	/// Proof: `Blaze::OutboundPool` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	fn submit_outbound_requests() -> Weight {
+	/// Storage: `BtcSocketQueue::Authority` (r:1 w:0)
+	/// Proof: `BtcSocketQueue::Authority` (`max_values`: Some(1), `max_size`: Some(20), mode: `MaxEncodedLen`)
+	/// Storage: `BtcSocketQueue::Socket` (r:1 w:0)
+	/// Proof: `BtcSocketQueue::Socket` (`max_values`: Some(1), `max_size`: Some(20), mode: `MaxEncodedLen`)
+	///
+	/// The `n` parameter represents the number of messages in the submission.
+	/// The `total_msg_bytes` parameter represents the total byte length of all messages.
+	/// Each message triggers a `verify_socket_message` call that reads `Authority` and `Socket`,
+	/// plus an EVM contract call for on-chain validation. Message bytes incur additional cost
+	/// from cloning, SCALE decoding/encoding, and keccak256 hashing.
+	fn submit_outbound_requests(n: u32, total_msg_bytes: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `1485`
 		// Minimum execution time: 18_800_000 picoseconds.
 		Weight::from_parts(19_410_000, 0)
+			// base: OutboundPool read + write
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			// per message: Authority + Socket reads for verify_socket_message
+			.saturating_add(RocksDbWeight::get().reads(2_u64.saturating_mul(n as u64)))
+			// per byte: clone, SCALE decode/encode, keccak256 hashing, storage encoding
+			.saturating_add(Weight::from_parts(1_500_u64.saturating_mul(total_msg_bytes as u64), 0))
 	}
 	/// Storage: `Blaze::IsActivated` (r:1 w:0)
 	/// Proof: `Blaze::IsActivated` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)

--- a/pallets/btc-registration-pool/src/mock.rs
+++ b/pallets/btc-registration-pool/src/mock.rs
@@ -109,6 +109,10 @@ impl SocketQueueManager<AccountId> for MockSocketQueue {
 		Ok(())
 	}
 
+	fn verify_legacy_authority(_: &AccountId) -> Result<(), TransactionValidityError> {
+		Ok(())
+	}
+
 	fn replace_authority(_: &AccountId, _: &AccountId) {}
 
 	fn get_max_fee_rate() -> u64 {

--- a/pallets/btc-socket-queue/src/migrations.rs
+++ b/pallets/btc-socket-queue/src/migrations.rs
@@ -1,5 +1,40 @@
 use super::*;
 
+pub mod v3 {
+	use super::*;
+	use core::marker::PhantomData;
+	use frame_support::{
+		traits::{Get, GetStorageVersion, OnRuntimeUpgrade},
+		weights::Weight,
+	};
+
+	pub struct V3<T>(PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for V3<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let mut weight = Weight::zero();
+
+			let current = Pallet::<T>::in_code_storage_version();
+			let onchain = Pallet::<T>::on_chain_storage_version();
+
+			// 1 read: on_chain_storage_version
+			weight = weight.saturating_add(T::DbWeight::get().reads(1));
+
+			if current == 3 && onchain == 2 {
+				<MaxSocketMessageBytes<T>>::put(T::DefaultMaxSocketMessageBytes::get());
+				current.put::<Pallet<T>>();
+
+				log!(info, "btc-socket-queue storage migration passes v3 update ✅");
+				// 2 writes: MaxSocketMessageBytes + storage version bump
+				weight = weight.saturating_add(T::DbWeight::get().writes(2));
+			} else {
+				log!(warn, "Skipping btc-socket-queue storage v3 💤");
+			}
+			weight
+		}
+	}
+}
+
 pub mod init_v2 {
 	use super::*;
 	use core::marker::PhantomData;

--- a/pallets/btc-socket-queue/src/mock.rs
+++ b/pallets/btc-socket-queue/src/mock.rs
@@ -50,6 +50,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 	pub const ExistentialDeposit: u128 = 1;
 	pub const DefaultMaxFeeRate: u64 = 1000;
+	pub const DefaultMaxSocketMessageBytes: u32 = 2 * 1024;
 	pub const MinimumPeriod: u64 = 6000;
 	pub PrecompilesValue: MockPrecompiles = MockPrecompiles;
 	pub WeightPerGas: frame_support::weights::Weight = frame_support::weights::Weight::from_parts(1, 0);
@@ -305,6 +306,7 @@ impl pallet_btc_socket_queue::Config for Test {
 	type Blaze = MockBlazeManager;
 	type WeightInfo = ();
 	type DefaultMaxFeeRate = DefaultMaxFeeRate;
+	type DefaultMaxSocketMessageBytes = DefaultMaxSocketMessageBytes;
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/pallets/btc-socket-queue/src/pallet/impls.rs
+++ b/pallets/btc-socket-queue/src/pallet/impls.rs
@@ -95,6 +95,10 @@ where
 		}
 		Ok(())
 	}
+
+	fn get_max_socket_message_bytes() -> u32 {
+		<MaxSocketMessageBytes<T>>::get()
+	}
 }
 
 impl<T: Config> SocketQueueManager<T::AccountId> for Pallet<T> {

--- a/pallets/btc-socket-queue/src/pallet/mod.rs
+++ b/pallets/btc-socket-queue/src/pallet/mod.rs
@@ -55,6 +55,8 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 		/// The maximum fee rate that can be set for PSBT.
 		type DefaultMaxFeeRate: Get<u64>;
+		/// The default maximum byte size of a single socket message.
+		type DefaultMaxSocketMessageBytes: Get<u32>;
 	}
 
 	#[pallet::error]
@@ -138,6 +140,8 @@ pub mod pallet {
 		SocketSet { new: T::AccountId, is_bitcoin: bool },
 		/// The maximum PSBT fee rate has been set.
 		MaxFeeRateSet { new: u64 },
+		/// The maximum socket message byte size has been set.
+		MaxSocketMessageBytesSet { new: u32 },
 		/// A relayer has confirmed the broadcast of an executed request.
 		BroadcastConfirmed { txid: H256, authority_id: T::AccountId },
 	}
@@ -214,6 +218,10 @@ pub mod pallet {
 	#[pallet::storage]
 	/// The maximum fee rate(sat/vb) that can be set for PSBT.
 	pub type MaxFeeRate<T: Config> = StorageValue<_, u64, ValueQuery>;
+
+	#[pallet::storage]
+	/// The maximum allowed byte size of a single socket message.
+	pub type MaxSocketMessageBytes<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	#[pallet::storage]
 	/// Broadcast confirmation votes for finalized requests (Blaze mode only).
@@ -368,6 +376,7 @@ pub mod pallet {
 				Authority::<T>::put(a);
 			}
 			<MaxFeeRate<T>>::put(T::DefaultMaxFeeRate::get());
+			<MaxSocketMessageBytes<T>>::put(T::DefaultMaxSocketMessageBytes::get());
 		}
 	}
 
@@ -963,6 +972,24 @@ pub mod pallet {
 			if T::Blaze::is_activated() {
 				T::Blaze::unlock_utxos(&txid)?;
 			}
+
+			Ok(().into())
+		}
+
+		#[pallet::call_index(11)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_max_socket_message_bytes())]
+		/// Set the maximum allowed byte size of a single socket message.
+		pub fn set_max_socket_message_bytes(
+			origin: OriginFor<T>,
+			new: u32,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+
+			let old = <MaxSocketMessageBytes<T>>::get();
+			ensure!(old != new, Error::<T>::NoWritingSameValue);
+
+			<MaxSocketMessageBytes<T>>::put(new);
+			Self::deposit_event(Event::MaxSocketMessageBytesSet { new });
 
 			Ok(().into())
 		}

--- a/pallets/btc-socket-queue/src/pallet/mod.rs
+++ b/pallets/btc-socket-queue/src/pallet/mod.rs
@@ -31,7 +31,7 @@ use sp_std::{vec, vec::Vec};
 pub mod pallet {
 	use super::*;
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -241,7 +241,7 @@ pub mod pallet {
 		H160: Into<T::AccountId>,
 	{
 		fn on_runtime_upgrade() -> Weight {
-			migrations::init_v2::InitV2::<T>::on_runtime_upgrade()
+			migrations::v3::V3::<T>::on_runtime_upgrade()
 		}
 
 		fn on_initialize(n: BlockNumberFor<T>) -> Weight {

--- a/pallets/btc-socket-queue/src/weights.rs
+++ b/pallets/btc-socket-queue/src/weights.rs
@@ -51,6 +51,7 @@ pub trait WeightInfo {
 	fn set_max_fee_rate() -> Weight;
 	fn submit_bump_fee_request() -> Weight;
 	fn drop_pending_rollback_request() -> Weight;
+	fn set_max_socket_message_bytes() -> Weight;
 }
 
 /// Weights for `pallet_btc_socket_queue` using the Substrate node and recommended hardware.
@@ -240,6 +241,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `1493`
+		// Minimum execution time: 16_830_000 picoseconds.
+		Weight::from_parts(17_380_000, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `BtcSocketQueue::MaxSocketMessageBytes` (r:1 w:1)
+	/// Proof: `BtcSocketQueue::MaxSocketMessageBytes` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	fn set_max_socket_message_bytes() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `1489`
 		// Minimum execution time: 16_830_000 picoseconds.
 		Weight::from_parts(17_380_000, 0)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
@@ -479,6 +491,17 @@ impl WeightInfo for () {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `1493`
+		// Minimum execution time: 16_830_000 picoseconds.
+		Weight::from_parts(17_380_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `BtcSocketQueue::MaxSocketMessageBytes` (r:1 w:1)
+	/// Proof: `BtcSocketQueue::MaxSocketMessageBytes` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	fn set_max_socket_message_bytes() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `1489`
 		// Minimum execution time: 16_830_000 picoseconds.
 		Weight::from_parts(17_380_000, 0)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))

--- a/pallets/cccp-relay-queue/src/lib.rs
+++ b/pallets/cccp-relay-queue/src/lib.rs
@@ -15,6 +15,9 @@ use scale_info::TypeInfo;
 use sp_core::{ConstU32, RuntimeDebug, H160, H256, U256};
 use sp_runtime::BoundedVec;
 
+/// Maximum number of pending transfers a single relayer may have at any time.
+pub const MAX_PENDING_TRANSFERS_PER_RELAYER: u32 = 100;
+
 /// Chain ID type.
 pub type ChainId = u32;
 

--- a/pallets/cccp-relay-queue/src/pallet/impls.rs
+++ b/pallets/cccp-relay-queue/src/pallet/impls.rs
@@ -271,6 +271,12 @@ impl<T: Config> Pallet<T> {
 
 impl<T: Config> RelayQueueManager<T::AccountId> for Pallet<T> {
 	fn replace_authority(old: &T::AccountId, new: &T::AccountId) {
+		// Migrate pending transfer count from old to new authority.
+		let old_count = <PendingTransferCount<T>>::take(old);
+		if old_count > 0 {
+			<PendingTransferCount<T>>::insert(new, old_count);
+		}
+
 		// Replace authority in all pending transfers (only handle on-flight voters. since finalization voters are handled in OnFlightTransfers)
 		PendingTransfers::<T>::translate::<TransferInfo<BalanceOf<T>, T::AccountId>, _>(
 			|_msg_hash, _src_tx_id, mut transfer_info| {

--- a/pallets/cccp-relay-queue/src/pallet/mod.rs
+++ b/pallets/cccp-relay-queue/src/pallet/mod.rs
@@ -95,6 +95,8 @@ pub mod pallet {
 		DuplicateAssetIndex,
 		/// Conflicting operations on the same asset index (add and remove).
 		ConflictingAssetIndexOperation,
+		/// The relayer has reached the maximum number of pending transfers.
+		PendingTransferCapExceeded,
 		/// Max on-flight cap must be greater than zero.
 		InvalidMaxCap,
 		/// Max on-flight cap exceeds maximum allowed value.
@@ -247,6 +249,14 @@ pub mod pallet {
 		SourceTransactionId,
 		TransferInfo<BalanceOf<T>, T::AccountId>,
 	>;
+
+	#[pallet::storage]
+	/// The number of pending transfers each relayer currently has introduced.
+	///
+	/// Key: Relayer account id (original submitter)
+	/// Value: Count of pending transfers
+	pub type PendingTransferCount<T: Config> =
+		StorageMap<_, Twox64Concat, T::AccountId, u32, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::unbounded]
@@ -452,6 +462,16 @@ pub mod pallet {
 				Error::<T>::TransferAlreadyFinalized
 			);
 
+			// Enforce per-relayer pending transfer cap for new entries before expensive validation.
+			let is_new_entry = !PendingTransfers::<T>::contains_key(msg_hash, src_tx_id);
+			if is_new_entry {
+				ensure!(
+					<PendingTransferCount<T>>::get(&authority_id)
+						< crate::MAX_PENDING_TRANSFERS_PER_RELAYER,
+					Error::<T>::PendingTransferCapExceeded
+				);
+			}
+
 			// Determine transfer option based on current cap:
 			// - If asset is registered with cap: Fast if cap allows, otherwise Standard
 			// - If asset is not registered: Always Standard (no Fast transfer support)
@@ -508,6 +528,13 @@ pub mod pallet {
 						Self::update_fast_transfer_cap(asset_id, asset_cap, amount.into(), true)?;
 					}
 				}
+				// Decrement pending transfer counts for all stored entries being cleared.
+				PendingTransfers::<T>::iter_prefix(msg_hash).for_each(|(_, info)| {
+					if let Some(submitter) = info.on_flight_voters.first() {
+						let count = <PendingTransferCount<T>>::get(submitter);
+						<PendingTransferCount<T>>::insert(submitter, count.saturating_sub(1));
+					}
+				});
 				// Clear every entry with the same msg_hash since the transaction with id=src_tx_id has met consensus
 				let _ = PendingTransfers::<T>::clear_prefix(msg_hash, u32::MAX, None);
 				OnFlightTransfers::<T>::insert(
@@ -516,6 +543,10 @@ pub mod pallet {
 				);
 				true
 			} else {
+				if is_new_entry {
+					let count = <PendingTransferCount<T>>::get(&authority_id);
+					<PendingTransferCount<T>>::insert(&authority_id, count + 1);
+				}
 				PendingTransfers::<T>::insert(msg_hash, src_tx_id, transfer_info);
 				false
 			};

--- a/pallets/cccp-relay-queue/src/pallet/mod.rs
+++ b/pallets/cccp-relay-queue/src/pallet/mod.rs
@@ -12,6 +12,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 
+use bp_cccp::traits::SocketVerifier;
 use bp_staking::traits::Authorities;
 use sp_core::{H160, U256};
 use sp_io::hashing::keccak_256;
@@ -38,6 +39,8 @@ pub mod pallet {
 		type Signer: IdentifyAccount<AccountId = Self::AccountId> + Encode + Decode + MaxEncodedLen;
 		/// The Bifrost relayers.
 		type Relayers: Authorities<Self::AccountId>;
+		/// Socket queue used to query the maximum allowed socket message byte size.
+		type SocketQueue: SocketVerifier<Self::AccountId>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}
@@ -1189,6 +1192,12 @@ pub mod pallet {
 				Call::on_flight_poll { on_flight_poll_submission, signature } => {
 					let OnFlightPollSubmission { authority_id, msg, msg_hash, src_tx_id } =
 						on_flight_poll_submission;
+
+					// reject if the message exceeds the configured size limit.
+					if msg.len() > T::SocketQueue::get_max_socket_message_bytes() as usize {
+						return InvalidTransaction::ExhaustsResources.into();
+					}
+
 					Self::verify_authority(authority_id)?;
 
 					// verify if the signature was originated from the authority_id.

--- a/pallets/relay-manager/src/mock.rs
+++ b/pallets/relay-manager/src/mock.rs
@@ -165,6 +165,10 @@ impl SocketQueueManager<AccountId> for MockSocketQueue {
 		Ok(())
 	}
 
+	fn verify_legacy_authority(_: &AccountId) -> Result<(), TransactionValidityError> {
+		Ok(())
+	}
+
 	fn replace_authority(_: &AccountId, _: &AccountId) {}
 
 	fn get_max_fee_rate() -> u64 {
@@ -178,6 +182,10 @@ impl SocketQueueManager<AccountId> for MockSocketQueue {
 impl SocketVerifier<AccountId> for MockSocketQueue {
 	fn verify_socket_message(_: &UnboundedBytes) -> Result<(), DispatchError> {
 		Ok(())
+	}
+
+	fn get_max_socket_message_bytes() -> u32 {
+		2 * 1024
 	}
 }
 

--- a/primitives/cccp/src/traits.rs
+++ b/primitives/cccp/src/traits.rs
@@ -5,6 +5,9 @@ use crate::UnboundedBytes;
 pub trait SocketVerifier<AccountId> {
 	/// Verify a Socket message whether it is valid.
 	fn verify_socket_message(msg: &UnboundedBytes) -> Result<(), DispatchError>;
+
+	/// Returns the maximum allowed byte size for a single socket message.
+	fn get_max_socket_message_bytes() -> u32;
 }
 
 pub trait RelayQueueManager<AccountId> {

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -849,6 +849,7 @@ impl pallet_cccp_relay_queue::Config for Runtime {
 	type Signature = EthereumSignature;
 	type Signer = EthereumSigner;
 	type Relayers = RelayManager;
+	type SocketQueue = BtcSocketQueue;
 	type WeightInfo = pallet_cccp_relay_queue::weights::SubstrateWeight<Runtime>;
 }
 
@@ -1080,6 +1081,7 @@ impl pallet_btc_socket_queue::Config for Runtime {
 	type Blaze = Blaze;
 	type WeightInfo = pallet_btc_socket_queue::weights::SubstrateWeight<Runtime>;
 	type DefaultMaxFeeRate = DefaultMaxFeeRate;
+	type DefaultMaxSocketMessageBytes = DefaultMaxSocketMessageBytes;
 }
 
 parameter_types! {
@@ -1087,6 +1089,7 @@ parameter_types! {
 	pub const BitcoinNetwork: Network = Network::Regtest;
 	pub const DefaultMultiSigRatio: Percent = Percent::from_percent(100);
 	pub const DefaultMaxFeeRate: u64 = 15;
+	pub const DefaultMaxSocketMessageBytes: u32 = 2 * 1024;
 }
 
 impl pallet_btc_registration_pool::Config for Runtime {

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -1073,6 +1073,7 @@ impl pallet_btc_socket_queue::Config for Runtime {
 	type Blaze = Blaze;
 	type WeightInfo = pallet_btc_socket_queue::weights::SubstrateWeight<Runtime>;
 	type DefaultMaxFeeRate = DefaultMaxFeeRate;
+	type DefaultMaxSocketMessageBytes = DefaultMaxSocketMessageBytes;
 }
 
 parameter_types! {
@@ -1080,6 +1081,7 @@ parameter_types! {
 	pub const BitcoinNetwork: Network = Network::Bitcoin;
 	pub const DefaultMultiSigRatio: Percent = Percent::from_percent(60);
 	pub const DefaultMaxFeeRate: u64 = 100;
+	pub const DefaultMaxSocketMessageBytes: u32 = 2 * 1024;
 }
 
 impl pallet_btc_registration_pool::Config for Runtime {

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -1106,6 +1106,7 @@ impl pallet_btc_socket_queue::Config for Runtime {
 	type Blaze = Blaze;
 	type WeightInfo = pallet_btc_socket_queue::weights::SubstrateWeight<Runtime>;
 	type DefaultMaxFeeRate = DefaultMaxFeeRate;
+	type DefaultMaxSocketMessageBytes = DefaultMaxSocketMessageBytes;
 }
 
 parameter_types! {
@@ -1113,6 +1114,7 @@ parameter_types! {
 	pub const BitcoinNetwork: Network = Network::Testnet;
 	pub const DefaultMultiSigRatio: Percent = Percent::from_percent(100);
 	pub const DefaultMaxFeeRate: u64 = 15;
+	pub const DefaultMaxSocketMessageBytes: u32 = 2 * 1024;
 }
 
 impl pallet_btc_registration_pool::Config for Runtime {


### PR DESCRIPTION
## Description

- introduce dynamic weight calculation for `submit_outbound_requests`
- set maximum byte size for submittable socket messages
- set maximum entities that are submittable through `submit_outbound_requests` and `submit_utxos`
- set maximum pending UTXO's and transfers per relayer to prevent storage growth

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
