### PR TITLE
feat: store historical relay executive members

### DIFF
--- a/pallets/blaze/src/mock.rs
+++ b/pallets/blaze/src/mock.rs
@@ -184,6 +184,10 @@ impl PoolManager<AccountId> for MockPoolManager {
 
 	fn process_set_refunds() {}
 
+	fn get_relay_executives(_: u32) -> Vec<AccountId> {
+		vec![]
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_benchmark(_: &[AccountId], _: &AccountId) -> Result<(), DispatchError> {
 		Ok(())

--- a/pallets/btc-registration-pool/src/lib.rs
+++ b/pallets/btc-registration-pool/src/lib.rs
@@ -13,6 +13,32 @@ pub mod weights;
 pub use pallet::pallet::*;
 use weights::WeightInfo;
 
+use frame_support::traits::{ChangeMembers, InitializeMembers};
+use sp_std::marker::PhantomData;
+
+/// Composes two [`ChangeMembers`] + [`InitializeMembers`] impls into one.
+/// Useful for wiring `pallet_membership::MembershipChanged` to multiple targets
+/// when the SDK does not provide blanket tuple impls for these traits.
+pub struct MembershipHook<A, B>(PhantomData<(A, B)>);
+
+impl<AccountId: Clone + Ord, A: ChangeMembers<AccountId>, B: ChangeMembers<AccountId>>
+	ChangeMembers<AccountId> for MembershipHook<A, B>
+{
+	fn change_members_sorted(incoming: &[AccountId], outgoing: &[AccountId], new: &[AccountId]) {
+		A::change_members_sorted(incoming, outgoing, new);
+		B::change_members_sorted(incoming, outgoing, new);
+	}
+}
+
+impl<AccountId, A: InitializeMembers<AccountId>, B: InitializeMembers<AccountId>>
+	InitializeMembers<AccountId> for MembershipHook<A, B>
+{
+	fn initialize_members(members: &[AccountId]) {
+		A::initialize_members(members);
+		B::initialize_members(members);
+	}
+}
+
 use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode};
 use scale_info::TypeInfo;
 use sp_core::RuntimeDebug;

--- a/pallets/btc-registration-pool/src/migrations.rs
+++ b/pallets/btc-registration-pool/src/migrations.rs
@@ -1,5 +1,38 @@
 use super::*;
 
+pub mod v2 {
+	use super::*;
+	use core::marker::PhantomData;
+	use frame_support::{
+		traits::{Get, GetStorageVersion, OnRuntimeUpgrade, SortedMembers},
+		weights::Weight,
+	};
+
+	pub struct V2<T>(PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for V2<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let mut weight = Weight::zero();
+
+			let current = Pallet::<T>::in_code_storage_version();
+			let onchain = Pallet::<T>::on_chain_storage_version();
+
+			if current == 2 && onchain == 1 {
+				<RelayExecutives<T>>::insert(
+					CurrentRound::<T>::get(),
+					&T::Executives::sorted_members(),
+				);
+				current.put::<Pallet<T>>();
+				weight = weight.saturating_add(T::DbWeight::get().writes(1));
+				log!(info, "btc-registration-pool storage migration passes v2 update ✅");
+			} else {
+				log!(warn, "Skipping btc-registration-pool storage v2 💤");
+			}
+			weight
+		}
+	}
+}
+
 pub mod init_v1 {
 	use core::marker::PhantomData;
 

--- a/pallets/btc-registration-pool/src/pallet/impls.rs
+++ b/pallets/btc-registration-pool/src/pallet/impls.rs
@@ -142,6 +142,10 @@ impl<T: Config> PoolManager<T::AccountId> for Pallet<T> {
 		});
 	}
 
+	fn get_relay_executives(round: u32) -> Vec<T::AccountId> {
+		RelayExecutives::<T>::get(round)
+	}
+
 	fn process_set_refunds() {
 		let round = <CurrentRound<T>>::get();
 		<PendingSetRefunds<T>>::iter_prefix(round).for_each(|(who, state)| {

--- a/pallets/btc-registration-pool/src/pallet/impls.rs
+++ b/pallets/btc-registration-pool/src/pallet/impls.rs
@@ -3,7 +3,7 @@ use bp_btc_relay::{
 	Address, AddressState, Descriptor, FromSliceError as KeyError, MigrationSequence,
 	MultiSigAccount, Network, PublicKey, UnboundedBytes,
 };
-use frame_support::traits::SortedMembers;
+use frame_support::traits::{ChangeMembers, InitializeMembers, SortedMembers};
 use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::prelude::{
 	format,
@@ -292,6 +292,28 @@ impl<T: Config> PoolManager<T::AccountId> for Pallet<T> {
 	fn set_service_state(state: MigrationSequence) -> Result<(), DispatchError> {
 		<ServiceState<T>>::put(state);
 		Ok(())
+	}
+}
+
+impl<T: Config> ChangeMembers<T::AccountId> for Pallet<T> {
+	fn change_members_sorted(
+		_incoming: &[T::AccountId],
+		_outgoing: &[T::AccountId],
+		new: &[T::AccountId],
+	) {
+		// During migration the new executives are for the upcoming round's vault,
+		// so write to current+1. In Normal state the current round is updated in place.
+		let round = match ServiceState::<T>::get() {
+			MigrationSequence::Normal => CurrentRound::<T>::get(),
+			_ => CurrentRound::<T>::get() + 1,
+		};
+		<RelayExecutives<T>>::insert(round, new.to_vec());
+	}
+}
+
+impl<T: Config> InitializeMembers<T::AccountId> for Pallet<T> {
+	fn initialize_members(members: &[T::AccountId]) {
+		<RelayExecutives<T>>::insert(1u32, members.to_vec());
 	}
 }
 

--- a/pallets/btc-registration-pool/src/pallet/mod.rs
+++ b/pallets/btc-registration-pool/src/pallet/mod.rs
@@ -30,7 +30,7 @@ use sp_std::{
 pub mod pallet {
 	use super::*;
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -147,6 +147,12 @@ pub mod pallet {
 	pub type CurrentRound<T: Config> = StorageValue<_, PoolRound, ValueQuery>;
 
 	#[pallet::storage]
+	#[pallet::unbounded]
+	/// The relay executive members. Snapshot of the executive members for vault migration.
+	pub type RelayExecutives<T: Config> =
+		StorageMap<_, Twox64Concat, PoolRound, Vec<T::AccountId>, ValueQuery>;
+
+	#[pallet::storage]
 	/// The migration sequence of the registration pool.
 	pub type ServiceState<T: Config> = StorageValue<_, MigrationSequence, ValueQuery>;
 
@@ -253,7 +259,7 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_runtime_upgrade() -> Weight {
-			migrations::init_v1::InitV1::<T>::on_runtime_upgrade()
+			migrations::v2::V2::<T>::on_runtime_upgrade()
 		}
 	}
 
@@ -695,6 +701,10 @@ pub mod pallet {
 					);
 					Self::deposit_event(Event::MigrationStarted);
 					<ServiceState<T>>::put(MigrationSequence::SetExecutiveMembers);
+					<RelayExecutives<T>>::insert(
+						CurrentRound::<T>::get(),
+						&T::Executives::sorted_members(),
+					);
 				},
 				MigrationSequence::SetExecutiveMembers => {
 					<ServiceState<T>>::put(MigrationSequence::PrepareNextSystemVault);
@@ -721,6 +731,10 @@ pub mod pallet {
 					<CurrentRound<T>>::mutate(|r| *r += 1);
 					<ServiceState<T>>::put(MigrationSequence::Normal);
 					<OngoingVaultMigration<T>>::put::<BTreeMap<H256, bool>>(Default::default());
+					<RelayExecutives<T>>::insert(
+						CurrentRound::<T>::get(),
+						&T::Executives::sorted_members(),
+					);
 				},
 			}
 

--- a/pallets/btc-registration-pool/src/pallet/mod.rs
+++ b/pallets/btc-registration-pool/src/pallet/mod.rs
@@ -148,7 +148,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::unbounded]
-	/// The relay executive members. Snapshot of the executive members for vault migration.
+	/// The relay executive members per round, kept in sync with T::Executives via ChangeMembers.
 	pub type RelayExecutives<T: Config> =
 		StorageMap<_, Twox64Concat, PoolRound, Vec<T::AccountId>, ValueQuery>;
 
@@ -727,10 +727,6 @@ pub mod pallet {
 					<CurrentRound<T>>::mutate(|r| *r += 1);
 					<ServiceState<T>>::put(MigrationSequence::Normal);
 					<OngoingVaultMigration<T>>::put::<BTreeMap<H256, bool>>(Default::default());
-					<RelayExecutives<T>>::insert(
-						CurrentRound::<T>::get(),
-						&T::Executives::sorted_members(),
-					);
 				},
 			}
 

--- a/pallets/btc-registration-pool/src/pallet/mod.rs
+++ b/pallets/btc-registration-pool/src/pallet/mod.rs
@@ -701,10 +701,6 @@ pub mod pallet {
 					);
 					Self::deposit_event(Event::MigrationStarted);
 					<ServiceState<T>>::put(MigrationSequence::SetExecutiveMembers);
-					<RelayExecutives<T>>::insert(
-						CurrentRound::<T>::get(),
-						&T::Executives::sorted_members(),
-					);
 				},
 				MigrationSequence::SetExecutiveMembers => {
 					<ServiceState<T>>::put(MigrationSequence::PrepareNextSystemVault);

--- a/pallets/btc-socket-queue/src/mock.rs
+++ b/pallets/btc-socket-queue/src/mock.rs
@@ -223,6 +223,10 @@ impl PoolManager<AccountId> for MockPoolManager {
 
 	fn process_set_refunds() {}
 
+	fn get_relay_executives(_: u32) -> Vec<AccountId> {
+		vec![]
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_benchmark(_: &[AccountId], _: &AccountId) -> Result<(), DispatchError> {
 		Ok(())

--- a/pallets/btc-socket-queue/src/pallet/mod.rs
+++ b/pallets/btc-socket-queue/src/pallet/mod.rs
@@ -1024,8 +1024,18 @@ pub mod pallet {
 				Call::submit_signed_psbt { msg, signature } => {
 					let SignedPsbtMessage { authority_id, signed_psbt, .. } = msg;
 
-					// verify if the authority is a relay executive member.
-					if !T::Executives::contains(&authority_id) {
+					// During UTXOTransfer the executive set may have rotated since the vault was
+					// built, so validate against the historical snapshot stored in the registration
+					// pool rather than the live T::Executives membership.
+					let is_valid_signer = if T::RegistrationPool::get_service_state()
+						== MigrationSequence::UTXOTransfer
+					{
+						let round = T::RegistrationPool::get_current_round();
+						T::RegistrationPool::get_relay_executives(round).contains(authority_id)
+					} else {
+						T::Executives::contains(authority_id)
+					};
+					if !is_valid_signer {
 						return InvalidTransaction::BadSigner.into();
 					}
 

--- a/pallets/relay-manager/src/mock.rs
+++ b/pallets/relay-manager/src/mock.rs
@@ -233,6 +233,10 @@ impl PoolManager<AccountId> for MockPoolManager {
 
 	fn process_set_refunds() {}
 
+	fn get_relay_executives(_: u32) -> Vec<AccountId> {
+		vec![]
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_benchmark(_: &[AccountId], _: &AccountId) -> Result<(), DispatchError> {
 		Ok(())

--- a/precompiles/btc-registration-pool/src/interface.sol
+++ b/precompiles/btc-registration-pool/src/interface.sol
@@ -21,6 +21,14 @@ interface BtcRegistrationPool {
     /// @param refund_address The registered refund address.
     event VaultPending(address user_bfc_address, string refund_address);
 
+    /// @dev Returns the relay executives of the given round.
+    /// @custom:selector 6c657541
+    /// @param pool_round The round number.
+    /// @return The relay executives of the given round.
+    function relay_executives(
+        uint32 pool_round
+    ) external view returns (address[] memory);
+
     /// @dev Returns the current round number.
     /// @custom:selector 319c068c
     /// @return The current round number.

--- a/precompiles/btc-registration-pool/src/lib.rs
+++ b/precompiles/btc-registration-pool/src/lib.rs
@@ -38,6 +38,22 @@ where
 	Runtime::RuntimeCall: From<BtcRegistrationPoolCall<Runtime>>,
 	<Runtime as pallet_evm::Config>::AddressMapping: AddressMapping<Runtime::AccountId>,
 {
+	#[precompile::public("relayExecutives(uint32)")]
+	#[precompile::public("relay_executives(uint32)")]
+	#[precompile::view]
+	fn relay_executives(
+		handle: &mut impl PrecompileHandle,
+		pool_round: PoolRound,
+	) -> EvmResult<Vec<Address>> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let relay_executives =
+			pallet_btc_registration_pool::RelayExecutives::<Runtime>::get(pool_round);
+		let relay_executives =
+			relay_executives.into_iter().map(|address| Address(address.into())).collect();
+		Ok(relay_executives)
+	}
+
 	#[precompile::public("currentRound()")]
 	#[precompile::public("current_round()")]
 	#[precompile::view]

--- a/primitives/btc-relay/src/traits.rs
+++ b/primitives/btc-relay/src/traits.rs
@@ -52,6 +52,9 @@ pub trait PoolManager<AccountId> {
 	/// Process the pending set refunds.
 	fn process_set_refunds();
 
+	/// Get the relay executive members snapshot for the given round.
+	fn get_relay_executives(round: u32) -> Vec<AccountId>;
+
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_benchmark(executives: &[AccountId], user: &AccountId) -> Result<(), DispatchError>;
 

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -589,8 +589,10 @@ impl pallet_membership::Config<pallet_membership::Instance3> for Runtime {
 	type AddOrigin = MoreThanTwoThirdsRelayExecutives;
 	type RuntimeEvent = RuntimeEvent;
 	type MaxMembers = RelayExecutivesMaxMembers;
-	type MembershipChanged = RelayExecutive;
-	type MembershipInitialized = RelayExecutive;
+	type MembershipChanged =
+		pallet_btc_registration_pool::MembershipHook<RelayExecutive, BtcRegistrationPool>;
+	type MembershipInitialized =
+		pallet_btc_registration_pool::MembershipHook<RelayExecutive, BtcRegistrationPool>;
 	type PrimeOrigin = MoreThanTwoThirdsRelayExecutives;
 	type RemoveOrigin = MoreThanTwoThirdsRelayExecutives;
 	type ResetOrigin = MoreThanTwoThirdsRelayExecutives;


### PR DESCRIPTION
## Description

Adds a RelayExecutives storage map to pallet-btc-registration-pool that snapshots the executive member set per pool round.

Changes:
- New `StorageMap<PoolRound, Vec<AccountId>>` (RelayExecutives) bumps pallet storage version to v2
- Snapshots are written at vault migration start and completion (`MigrationSequence::Normal`)
- v2 runtime migration backfills the snapshot for the current round on upgrade
- Exposes `relay_executives(uint32)` as a read-only precompile method on BtcRegistrationPool

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
