### PR TITLE
chore(deps): bump polkadot-sdk to latest commit and release v2048

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "hash-db",
  "log",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -2632,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2649,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "16.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2690,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4110,7 +4110,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4292,7 +4292,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4423,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4453,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.13.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -4469,7 +4469,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.4.0",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4566,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4585,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4609,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7669,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7685,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7713,7 +7713,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7857,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7946,7 +7946,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7963,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8087,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8122,7 +8122,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8138,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8157,7 +8157,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "15.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8188,7 +8188,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8223,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8239,7 +8239,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "26.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -8286,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8303,7 +8303,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8325,7 +8325,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8361,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8379,7 +8379,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "48.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8411,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8442,7 +8442,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "26.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -8453,7 +8453,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8797,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8808,7 +8808,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bs58",
  "futures 0.3.31",
@@ -8825,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8874,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -8902,7 +8902,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -8939,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -8980,7 +8980,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -10455,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "log",
  "sp-core",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -10498,7 +10498,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10535,7 +10535,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -10561,7 +10561,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "bip39",
@@ -10614,7 +10614,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -10640,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10668,7 +10668,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -10691,7 +10691,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10722,7 +10722,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10759,7 +10759,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.40.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.40.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.31",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.56.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -10894,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -10917,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "log",
  "polkavm",
@@ -10941,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "anyhow",
  "log",
@@ -10957,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "console",
  "futures 0.3.31",
@@ -10973,7 +10973,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -10987,7 +10987,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -11015,7 +11015,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -11064,7 +11064,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -11074,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "ahash 0.8.12",
  "futures 0.3.31",
@@ -11093,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -11114,7 +11114,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -11149,7 +11149,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -11168,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bs58",
  "bytes",
@@ -11189,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bytes",
  "fnv",
@@ -11223,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11232,7 +11232,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -11264,7 +11264,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11284,7 +11284,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -11308,7 +11308,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -11341,7 +11341,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -11356,7 +11356,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "directories",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11431,7 +11431,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "derive_more 0.99.20",
  "futures 0.3.31",
@@ -11451,7 +11451,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -11470,7 +11470,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "chrono",
  "console",
@@ -11498,7 +11498,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -11509,7 +11509,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11541,7 +11541,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11559,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -12348,7 +12348,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "hash-db",
@@ -12370,7 +12370,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12384,7 +12384,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12396,7 +12396,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -12410,7 +12410,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12422,7 +12422,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -12451,7 +12451,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12465,7 +12465,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12481,7 +12481,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12499,7 +12499,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12516,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12527,7 +12527,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -12588,7 +12588,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12601,7 +12601,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512)",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
@@ -12621,7 +12621,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12631,7 +12631,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12641,7 +12641,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12653,7 +12653,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bytes",
  "docify",
@@ -12692,7 +12692,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -12702,7 +12702,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -12713,7 +12713,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -12722,7 +12722,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -12732,7 +12732,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12743,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12760,7 +12760,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12773,7 +12773,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12783,7 +12783,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "backtrace",
  "regex",
@@ -12792,7 +12792,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -12802,7 +12802,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -12833,7 +12833,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12851,7 +12851,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "Inflector",
  "expander",
@@ -12864,7 +12864,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12878,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -12891,7 +12891,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "hash-db",
  "log",
@@ -12911,7 +12911,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -12935,12 +12935,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12952,7 +12952,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12964,7 +12964,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -12976,7 +12976,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12985,7 +12985,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12999,7 +12999,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -13024,7 +13024,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13041,7 +13041,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -13053,7 +13053,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13065,7 +13065,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13239,7 +13239,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -13260,7 +13260,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "environmental",
  "frame-support",
@@ -13284,7 +13284,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "24.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -13385,7 +13385,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -13410,7 +13410,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 
 [[package]]
 name = "substrate-fixed"
@@ -13426,7 +13426,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -13446,7 +13446,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -13470,7 +13470,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -14246,7 +14246,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -14257,7 +14257,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -15700,7 +15700,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#75d9550f7b524023453a03c769567c342c5f8241"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -157,7 +157,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the authorship interface.
 	authoring_version: 1,
 	// The version of the runtime spec.
-	spec_version: 2047,
+	spec_version: 2048,
 	// The version of the implementation of the spec.
 	impl_version: 1,
 	// A list of supported runtime APIs along with their versions.


### PR DESCRIPTION
## Description

- Bump polkadot-sdk (https://github.com/bifrost-platform/polkadot-sdk/pull/5)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
