### PR TITLE
chore(deps): bump parity-db to v0.5.6 and release node v2.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "bifrost-node"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bifrost-common-node",
  "bifrost-dev-node",
@@ -1446,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "hash-db",
  "log",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -2632,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2649,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "16.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2690,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3599,7 +3599,7 @@ dependencies = [
 [[package]]
 name = "evm-tracer"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum-types",
  "evm",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3719,7 +3719,7 @@ dependencies = [
  "futures 0.3.31",
  "kvdb-rocksdb",
  "log",
- "parity-db 0.5.4",
+ "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.5",
  "sc-client-api",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "fc-evm-tracing"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum-types",
  "fp-rpc-debug",
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core-debug"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core-trace"
 version = "0.6.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum-types",
  "fc-evm-tracing",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core-types"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum-types",
  "serde",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-debug"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-trace"
 version = "0.6.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4110,7 +4110,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4137,7 +4137,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4178,7 +4178,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "environmental",
  "evm",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "fp-ext"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum-types",
  "fp-rpc-evm-tracing-events",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc-debug"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc-evm-tracing-events"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "environmental",
  "ethereum",
@@ -4251,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc-txpool"
 version = "0.6.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -4292,7 +4292,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4423,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4453,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.13.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -4469,7 +4469,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.4.0",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4566,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4585,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4609,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6902,15 +6902,6 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memmap2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
@@ -7651,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7669,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7685,7 +7676,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7700,7 +7691,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7713,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7736,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7752,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7857,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7946,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7963,7 +7954,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7980,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -8003,7 +7994,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -8028,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "fp-evm",
 ]
@@ -8036,7 +8027,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -8046,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "fp-evm",
  "num",
@@ -8055,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -8065,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8087,7 +8078,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8103,7 +8094,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8122,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8138,7 +8129,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8157,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "15.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8176,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8188,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8223,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8239,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8272,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "26.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -8286,7 +8277,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8303,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8325,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8346,7 +8337,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8361,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8379,7 +8370,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8395,7 +8386,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "48.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8411,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8423,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8442,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "26.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -8453,7 +8444,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8467,10 +8458,11 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.13"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592a28a24b09c9dc20ac8afaa6839abc417c720afe42c12e1e4a9d6aa2508d2e"
+checksum = "cd67682e0852e7b476b8502a4abe27890f82d3c482a65e4acf985d17f6048f9d"
 dependencies = [
+ "ahash 0.8.12",
  "blake2 0.10.6",
  "crc32fast",
  "fs2",
@@ -8478,31 +8470,10 @@ dependencies = [
  "libc",
  "log",
  "lz4",
- "memmap2 0.5.10",
- "parking_lot 0.12.5",
- "rand 0.8.5",
- "siphasher 0.3.11",
- "snap",
- "winapi",
-]
-
-[[package]]
-name = "parity-db"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6985a45b0597d68448dac9db2907f9f72bbaf63fe3383d4ba15f99096c87212f"
-dependencies = [
- "blake2 0.10.6",
- "crc32fast",
- "fs2",
- "hex",
- "libc",
- "log",
- "lz4",
- "memmap2 0.9.9",
+ "memmap2",
  "parking_lot 0.12.5",
  "rand 0.9.2",
- "siphasher 1.0.1",
+ "siphasher",
  "snap",
  "winapi",
 ]
@@ -8797,7 +8768,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8808,7 +8779,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bs58",
  "futures 0.3.31",
@@ -8825,7 +8796,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8850,7 +8821,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8874,7 +8845,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -8902,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -8922,7 +8893,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -8939,7 +8910,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -8968,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -8980,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -9027,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9062,7 +9033,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9399,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "environmental",
  "evm",
@@ -9423,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#536257eed843936c067add3bb3104c4fa7d50511"
+source = "git+https://github.com/bifrost-platform/bifrost-frontier?branch=bifrost-polkadot-stable2512#b96e6d5dd10a80465e2c00afffcacd3a430e05b4"
 dependencies = [
  "case",
  "num_enum",
@@ -10455,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "log",
  "sp-core",
@@ -10466,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -10498,7 +10469,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -10520,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10535,11 +10506,11 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
- "memmap2 0.9.9",
+ "memmap2",
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-client-api",
@@ -10561,7 +10532,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -10572,7 +10543,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "bip39",
@@ -10614,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -10640,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10648,7 +10619,7 @@ dependencies = [
  "kvdb-rocksdb",
  "linked-hash-map",
  "log",
- "parity-db 0.4.13",
+ "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.5",
  "sc-client-api",
@@ -10668,7 +10639,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -10691,7 +10662,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10722,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10759,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10772,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.40.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -10816,7 +10787,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.40.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.31",
@@ -10836,7 +10807,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.56.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -10871,7 +10842,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -10894,7 +10865,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -10917,7 +10888,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -10930,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "log",
  "polkavm",
@@ -10941,7 +10912,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "anyhow",
  "log",
@@ -10957,7 +10928,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "console",
  "futures 0.3.31",
@@ -10973,7 +10944,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -10987,7 +10958,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -11015,7 +10986,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -11064,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -11074,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "ahash 0.8.12",
  "futures 0.3.31",
@@ -11093,7 +11064,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -11114,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -11149,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -11168,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bs58",
  "bytes",
@@ -11189,7 +11160,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bytes",
  "fnv",
@@ -11223,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11232,7 +11203,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -11264,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11284,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -11308,7 +11279,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -11341,7 +11312,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -11356,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "directories",
@@ -11420,7 +11391,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11431,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "derive_more 0.99.20",
  "futures 0.3.31",
@@ -11451,7 +11422,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -11470,7 +11441,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "chrono",
  "console",
@@ -11498,7 +11469,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -11509,7 +11480,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11541,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11559,7 +11530,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -12148,12 +12119,6 @@ checksum = "620a1d43d70e142b1d46a929af51d44f383db9c7a2ec122de2cd992ccfcf3c18"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
@@ -12240,7 +12205,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha3",
- "siphasher 1.0.1",
+ "siphasher",
  "slab",
  "smallvec",
  "soketto",
@@ -12279,7 +12244,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
- "siphasher 1.0.1",
+ "siphasher",
  "slab",
  "smol",
  "smoldot",
@@ -12348,7 +12313,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "hash-db",
@@ -12370,7 +12335,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12384,7 +12349,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12396,7 +12361,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -12410,7 +12375,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12422,7 +12387,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12432,7 +12397,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -12451,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12465,7 +12430,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12481,7 +12446,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12499,7 +12464,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12516,7 +12481,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12527,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -12588,7 +12553,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12601,7 +12566,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512)",
@@ -12611,7 +12576,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
@@ -12621,7 +12586,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12631,7 +12596,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12641,7 +12606,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12653,7 +12618,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12666,7 +12631,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bytes",
  "docify",
@@ -12692,7 +12657,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -12702,7 +12667,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -12713,7 +12678,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -12722,7 +12687,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -12732,7 +12697,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12743,7 +12708,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12760,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12773,7 +12738,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12783,7 +12748,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "backtrace",
  "regex",
@@ -12792,7 +12757,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -12802,7 +12767,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -12833,7 +12798,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12851,7 +12816,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "Inflector",
  "expander",
@@ -12864,7 +12829,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12878,7 +12843,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -12891,7 +12856,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "hash-db",
  "log",
@@ -12911,7 +12876,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -12935,12 +12900,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12952,7 +12917,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12964,7 +12929,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -12976,7 +12941,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12985,7 +12950,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12999,7 +12964,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -13024,7 +12989,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13041,7 +13006,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -13053,7 +13018,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13065,7 +13030,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -13239,7 +13204,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -13260,7 +13225,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "environmental",
  "frame-support",
@@ -13284,7 +13249,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "24.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -13385,7 +13350,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -13410,7 +13375,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 
 [[package]]
 name = "substrate-fixed"
@@ -13426,7 +13391,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -13446,7 +13411,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -13470,7 +13435,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.1.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -14246,7 +14211,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -14257,7 +14222,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -15700,7 +15665,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#be70b7ede2c586ee1384fb0a48b2cf5a8e1fb315"
+source = "git+https://github.com/bifrost-platform/polkadot-sdk?branch=bifrost-polkadot-stable2512#940ed67217bcc5b6c0770bbdf618b9f5191a3a04"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/node/core/Cargo.toml
+++ b/node/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bifrost-node"
-version = "2.2.1"
+version = "2.2.2"
 description = "The node client implementation for Bifrost"
 authors = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
## Description

- Bumped `parity-db` to `v0.5.6`, consolidating the previously mixed `0.4.13` / `0.5.4` dependency tree onto a single version
- Picks up [paritytech/parity-db#252](https://github.com/paritytech/parity-db/pull/252) ("fix: deadlock between commit worker and cleanup worker")
  - Under a sustained enactment backlog (log enactment falling behind log flushing), the commit worker could park waiting on the log-cleanup cap while the cleanup worker was never signalled, deadlocking both
  - The commit worker now signals the cleanup worker before parking, so cleanup can make progress and release the cap
- Propagated through the dependency stack via:
  - polkadot-sdk fork: [bifrost-platform/polkadot-sdk#6](https://github.com/bifrost-platform/polkadot-sdk/pull/6)
  - bifrost-frontier: [`b96e6d5`](https://github.com/bifrost-platform/bifrost-frontier/commit/b96e6d5dd10a80465e2c00afffcacd3a430e05b4)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
